### PR TITLE
修復 Agent 設定頁面啟用/停用提示訊息顯示位置

### DIFF
--- a/AiTeam.Tests/Pages/AgentSettingsTests.cs
+++ b/AiTeam.Tests/Pages/AgentSettingsTests.cs
@@ -1,0 +1,347 @@
+
+```csharp
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using AiTeam.Pages;
+using AiTeam.Services;
+using AiTeam.Models;
+using Moq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace AiTeam.Tests.Pages
+{
+    public class AgentSettingsTests : TestContext
+    {
+        private readonly Mock<IAgentService> _mockAgentService;
+
+        public AgentSettingsTests()
+        {
+            _mockAgentService = new Mock<IAgentService>();
+            Services.AddSingleton(_mockAgentService.Object);
+        }
+
+        private AgentModel CreateTestAgent(bool isEnabled = true)
+        {
+            return new AgentModel
+            {
+                Id = "test-agent-1",
+                Name = "Test Agent",
+                Description = "Test Description",
+                IsEnabled = isEnabled
+            };
+        }
+
+        [Fact]
+        public void AgentSettings_WhenLoaded_ShouldDisplayAgentList()
+        {
+            // Arrange
+            var agents = new List<AgentModel>
+            {
+                CreateTestAgent(true),
+                CreateTestAgent(false)
+            };
+            agents[1].Id = "test-agent-2";
+            agents[1].Name = "Test Agent 2";
+
+            _mockAgentService.Setup(s => s.GetAgentsAsync())
+                .ReturnsAsync(agents);
+
+            // Act
+            var component = RenderComponent<AgentSettings>();
+
+            // Assert
+            var agentItems = component.FindAll(".agent-item");
+            Assert.Equal(2, agentItems.Count);
+        }
+
+        [Fact]
+        public void AgentSettings_WhenAgentEnabled_ShouldShowEnabledStatus()
+        {
+            // Arrange
+            var agents = new List<AgentModel> { CreateTestAgent(true) };
+            _mockAgentService.Setup(s => s.GetAgentsAsync())
+                .ReturnsAsync(agents);
+
+            // Act
+            var component = RenderComponent<AgentSettings>();
+
+            // Assert
+            var toggleButton = component.Find(".toggle-button");
+            Assert.Contains("enabled", toggleButton.ClassList);
+        }
+
+        [Fact]
+        public void AgentSettings_WhenAgentDisabled_ShouldShowDisabledStatus()
+        {
+            // Arrange
+            var agents = new List<AgentModel> { CreateTestAgent(false) };
+            _mockAgentService.Setup(s => s.GetAgentsAsync())
+                .ReturnsAsync(agents);
+
+            // Act
+            var component = RenderComponent<AgentSettings>();
+
+            // Assert
+            var toggleButton = component.Find(".toggle-button");
+            Assert.DoesNotContain("enabled", toggleButton.ClassList);
+        }
+
+        [Fact]
+        public async Task AgentSettings_WhenToggleEnabled_ShouldShowSuccessMessage()
+        {
+            // Arrange
+            var agent = CreateTestAgent(false);
+            var agents = new List<AgentModel> { agent };
+            
+            _mockAgentService.Setup(s => s.GetAgentsAsync())
+                .ReturnsAsync(agents);
+            _mockAgentService.Setup(s => s.UpdateAgentStatusAsync(agent.Id, true))
+                .ReturnsAsync(true);
+
+            // Act
+            var component = RenderComponent<AgentSettings>();
+            var toggleButton = component.Find(".toggle-button");
+            await toggleButton.ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+            // Assert
+            var notification = component.Find(".notification-area");
+            Assert.NotNull(notification);
+            
+            var message = component.Find(".notification-message");
+            Assert.NotNull(message);
+            Assert.Contains("啟用", message.TextContent);
+        }
+
+        [Fact]
+        public async Task AgentSettings_WhenToggleDisabled_ShouldShowSuccessMessage()
+        {
+            // Arrange
+            var agent = CreateTestAgent(true);
+            var agents = new List<AgentModel> { agent };
+            
+            _mockAgentService.Setup(s => s.GetAgentsAsync())
+                .ReturnsAsync(agents);
+            _mockAgentService.Setup(s => s.UpdateAgentStatusAsync(agent.Id, false))
+                .ReturnsAsync(true);
+
+            // Act
+            var component = RenderComponent<AgentSettings>();
+            var toggleButton = component.Find(".toggle-button");
+            await toggleButton.ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+            // Assert
+            var notification = component.Find(".notification-area");
+            Assert.NotNull(notification);
+            
+            var message = component.Find(".notification-message");
+            Assert.NotNull(message);
+            Assert.Contains("停用", message.TextContent);
+        }
+
+        [Fact]
+        public async Task AgentSettings_NotificationMessage_ShouldBeInCorrectPosition()
+        {
+            // Arrange
+            var agent = CreateTestAgent(false);
+            var agents = new List<AgentModel> { agent };
+            
+            _mockAgentService.Setup(s => s.GetAgentsAsync())
+                .ReturnsAsync(agents);
+            _mockAgentService.Setup(s => s.UpdateAgentStatusAsync(agent.Id, true))
+                .ReturnsAsync(true);
+
+            // Act
+            var component = RenderComponent<AgentSettings>();
+            var toggleButton = component.Find(".toggle-button");
+            await toggleButton.ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+            // Assert - Verify notification is inside the notification-area, not elsewhere
+            var notificationArea = component.Find(".notification-area");
+            Assert.NotNull(notificationArea);
+            
+            // Verify the message is a child of notification-area (correct position)
+            var messageInNotificationArea = notificationArea.QuerySelector(".notification-message");
+            Assert.NotNull(messageInNotificationArea);
+            
+            // Verify there's no stray notification outside the notification-area
+            var allMessages = component.FindAll(".notification-message");
+            Assert.Single(allMessages);
+        }
+
+        [Fact]
+        public async Task AgentSettings_NotificationMessage_ShouldBeNearToggleButton()
+        {
+            // Arrange
+            var agent = CreateTestAgent(false);
+            var agents = new List<AgentModel> { agent };
+            
+            _mockAgentService.Setup(s => s.GetAgentsAsync())
+                .ReturnsAsync(agents);
+            _mockAgentService.Setup(s => s.UpdateAgentStatusAsync(agent.Id, true))
+                .ReturnsAsync(true);
+
+            // Act
+            var component = RenderComponent<AgentSettings>();
+            var toggleButton = component.Find(".toggle-button");
+            await toggleButton.ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+            // Assert - Verify the agent-item contains both toggle button and status message
+            var agentItem = component.Find(".agent-item");
+            Assert.NotNull(agentItem);
+            
+            var toggleInItem = agentItem.QuerySelector(".toggle-button");
+            Assert.NotNull(toggleInItem);
+            
+            // The notification should be in agent-controls section near the toggle
+            var agentControls = agentItem.QuerySelector(".agent-controls");
+            Assert.NotNull(agentControls);
+            
+            var notificationInControls = agentControls.QuerySelector(".status-message");
+            Assert.NotNull(notificationInControls);
+        }
+
+        [Fact]
+        public async Task AgentSettings_WhenToggleFails_ShouldShowErrorMessage()
+        {
+            // Arrange
+            var agent = CreateTestAgent(false);
+            var agents = new List<AgentModel> { agent };
+            
+            _mockAgentService.Setup(s => s.GetAgentsAsync())
+                .ReturnsAsync(agents);
+            _mockAgentService.Setup(s => s.UpdateAgentStatusAsync(agent.Id, true))
+                .ReturnsAsync(false);
+
+            // Act
+            var component = RenderComponent<AgentSettings>();
+            var toggleButton = component.Find(".toggle-button");
+            await toggleButton.ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+            // Assert
+            var errorMessage = component.Find(".error-message");
+            Assert.NotNull(errorMessage);
+            Assert.Contains("失敗", errorMessage.TextContent);
+        }
+
+        [Fact]
+        public async Task AgentSettings_SuccessMessage_ShouldHaveCorrectCssClass()
+        {
+            // Arrange
+            var agent = CreateTestAgent(false);
+            var agents = new List<AgentModel> { agent };
+            
+            _mockAgentService.Setup(s => s.GetAgentsAsync())
+                .ReturnsAsync(agents);
+            _mockAgentService.Setup(s => s.UpdateAgentStatusAsync(agent.Id, true))
+                .ReturnsAsync(true);
+
+            // Act
+            var component = RenderComponent<AgentSettings>();
+            var toggleButton = component.Find(".toggle-button");
+            await toggleButton.ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+            // Assert - Success message should have 'success' CSS class for proper styling
+            var statusMessage = component.Find(".status-message");
+            Assert.Contains("success", statusMessage.ClassList);
+        }
+
+        [Fact]
+        public async Task AgentSettings_ErrorMessage_ShouldHaveCorrectCssClass()
+        {
+            // Arrange
+            var agent = CreateTestAgent(false);
+            var agents = new List<AgentModel> { agent };
+            
+            _mockAgentService.Setup(s => s.GetAgentsAsync())
+                .ReturnsAsync(agents);
+            _mockAgentService.Setup(s => s.UpdateAgentStatusAsync(agent.Id, true))
+                .ReturnsAsync(false);
+
+            // Act
+            var component = RenderComponent<AgentSettings>();
+            var toggleButton = component.Find(".toggle-button");
+            await toggleButton.ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+            // Assert - Error message should have 'error' CSS class for proper styling
+            var statusMessage = component.Find(".status-message");
+            Assert.Contains("error", statusMessage.ClassList);
+        }
+
+        [Fact]
+        public void AgentSettings_InitialState_ShouldNotShowNotification()
+        {
+            // Arrange
+            var agents = new List<AgentModel> { CreateTestAgent(true) };
+            _mockAgentService.Setup(s => s.GetAgentsAsync())
+                .ReturnsAsync(agents);
+
+            // Act
+            var component = RenderComponent<AgentSettings>();
+
+            // Assert - No notification should be visible on initial load
+            var notifications = component.FindAll(".status-message");
+            Assert.Empty(notifications);
+        }
+
+        [Fact]
+        public async Task AgentSettings_MultipleAgents_NotificationShouldAppearForCorrectAgent()
+        {
+            // Arrange
+            var agent1 = CreateTestAgent(false);
+            var agent2 = new AgentModel
+            {
+                Id = "test-agent-2",
+                Name = "Test Agent 2",
+                IsEnabled = true
+            };
+            
+            var agents = new List<AgentModel> { agent1, agent2 };
+            
+            _mockAgentService.Setup(s => s.GetAgentsAsync())
+                .ReturnsAsync(agents);
+            _mockAgentService.Setup(s => s.UpdateAgentStatusAsync(agent1.Id, true))
+                .ReturnsAsync(true);
+
+            // Act
+            var component = RenderComponent<AgentSettings>();
+            var toggleButtons = component.FindAll(".toggle-button");
+            await toggleButtons[0].ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+            // Assert - Only the first agent item should show notification
+            var agentItems = component.FindAll(".agent-item");
+            
+            var firstAgentMessage = agentItems[0].QuerySelector(".status-message");
+            Assert.NotNull(firstAgentMessage);
+            
+            var secondAgentMessage = agentItems[1].QuerySelector(".status-message");
+            Assert.Null(secondAgentMessage);
+        }
+
+        [Fact]
+        public async Task AgentSettings_NotificationArea_ShouldHaveProperAriaAttributes()
+        {
+            // Arrange
+            var agent = CreateTestAgent(false);
+            var agents = new List<AgentModel> { agent };
+            
+            _mockAgentService.Setup(s => s.GetAgentsAsync())
+                .ReturnsAsync(agents);
+            _mockAgentService.Setup(s => s.UpdateAgentStatusAsync(agent.Id, true))
+                .ReturnsAsync(true);
+
+            // Act
+            var component = RenderComponent<AgentSettings>();
+            var toggleButton = component.Find(".toggle-button");
+            await toggleButton.ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+            // Assert - Notification should have aria-live for accessibility
+            var notification = component.Find(".notification-area");
+            Assert.NotNull(notification);
+            Assert.Equal("polite", notification.GetAttribute("aria-live"));
+        }
+    }
+}
+```

--- a/AiTeam/Pages/AgentSettings.razor
+++ b/AiTeam/Pages/AgentSettings.razor
@@ -1,0 +1,313 @@
+
+```csharp
+@page "/agent-settings"
+@using Microsoft.AspNetCore.Components
+@using System.Timers
+
+<div class="agent-settings-container">
+    <h2>Agent 設定</h2>
+    
+    @if (!string.IsNullOrEmpty(StatusMessage))
+    {
+        <div class="notification-area @(IsSuccess ? "notification-success" : "notification-error")" role="alert">
+            <span class="notification-icon">@(IsSuccess ? "✓" : "✗")</span>
+            <span class="notification-text">@StatusMessage</span>
+            <button class="notification-close" @onclick="ClearStatusMessage">×</button>
+        </div>
+    }
+    
+    <div class="agents-list">
+        @foreach (var agent in Agents)
+        {
+            <div class="agent-card @(agent.IsEnabled ? "agent-enabled" : "agent-disabled")">
+                <div class="agent-info">
+                    <h3>@agent.Name</h3>
+                    <p>@agent.Description</p>
+                </div>
+                <div class="agent-toggle-section">
+                    <div class="toggle-container">
+                        <label class="toggle-switch">
+                            <input type="checkbox" 
+                                   checked="@agent.IsEnabled" 
+                                   @onchange="(e) => ToggleAgent(agent, (bool)e.Value!)" />
+                            <span class="toggle-slider"></span>
+                        </label>
+                        <span class="toggle-label">@(agent.IsEnabled ? "啟用" : "停用")</span>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+</div>
+
+<style>
+    .agent-settings-container {
+        padding: 20px;
+        max-width: 800px;
+        margin: 0 auto;
+        position: relative;
+    }
+
+    .notification-area {
+        position: fixed;
+        top: 20px;
+        right: 20px;
+        z-index: 1000;
+        padding: 12px 16px;
+        border-radius: 8px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-width: 250px;
+        max-width: 400px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        animation: slideIn 0.3s ease-out;
+    }
+
+    @@keyframes slideIn {
+        from {
+            transform: translateX(100%);
+            opacity: 0;
+        }
+        to {
+            transform: translateX(0);
+            opacity: 1;
+        }
+    }
+
+    .notification-success {
+        background-color: #d4edda;
+        border: 1px solid #c3e6cb;
+        color: #155724;
+    }
+
+    .notification-error {
+        background-color: #f8d7da;
+        border: 1px solid #f5c6cb;
+        color: #721c24;
+    }
+
+    .notification-icon {
+        font-size: 16px;
+        font-weight: bold;
+    }
+
+    .notification-text {
+        flex: 1;
+        font-size: 14px;
+    }
+
+    .notification-close {
+        background: none;
+        border: none;
+        font-size: 18px;
+        cursor: pointer;
+        opacity: 0.7;
+        padding: 0 4px;
+        line-height: 1;
+    }
+
+    .notification-close:hover {
+        opacity: 1;
+    }
+
+    .agents-list {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        margin-top: 20px;
+    }
+
+    .agent-card {
+        border: 1px solid #dee2e6;
+        border-radius: 8px;
+        padding: 16px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background-color: #fff;
+        transition: all 0.2s ease;
+    }
+
+    .agent-enabled {
+        border-left: 4px solid #28a745;
+    }
+
+    .agent-disabled {
+        border-left: 4px solid #dc3545;
+        opacity: 0.8;
+    }
+
+    .agent-info h3 {
+        margin: 0 0 4px 0;
+        font-size: 16px;
+    }
+
+    .agent-info p {
+        margin: 0;
+        color: #6c757d;
+        font-size: 14px;
+    }
+
+    .agent-toggle-section {
+        display: flex;
+        align-items: center;
+    }
+
+    .toggle-container {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 50px;
+        height: 26px;
+    }
+
+    .toggle-switch input {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+
+    .toggle-slider {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: #dc3545;
+        border-radius: 26px;
+        transition: 0.3s;
+    }
+
+    .toggle-slider:before {
+        position: absolute;
+        content: "";
+        height: 20px;
+        width: 20px;
+        left: 3px;
+        bottom: 3px;
+        background-color: white;
+        border-radius: 50%;
+        transition: 0.3s;
+    }
+
+    input:checked + .toggle-slider {
+        background-color: #28a745;
+    }
+
+    input:checked + .toggle-slider:before {
+        transform: translateX(24px);
+    }
+
+    .toggle-label {
+        font-size: 14px;
+        min-width: 32px;
+    }
+</style>
+
+@code {
+    private List<AgentModel> Agents { get; set; } = new();
+    private string StatusMessage { get; set; } = string.Empty;
+    private bool IsSuccess { get; set; } = true;
+    private Timer? _dismissTimer;
+
+    protected override void OnInitialized()
+    {
+        LoadAgents();
+    }
+
+    private void LoadAgents()
+    {
+        Agents = new List<AgentModel>
+        {
+            new AgentModel { Id = "1", Name = "客服 Agent", Description = "處理客戶服務相關請求", IsEnabled = true },
+            new AgentModel { Id = "2", Name = "分析 Agent", Description = "執行數據分析任務", IsEnabled = true },
+            new AgentModel { Id = "3", Name = "報告 Agent", Description = "生成自動化報告", IsEnabled = false },
+            new AgentModel { Id = "4", Name = "監控 Agent", Description = "系統監控與告警", IsEnabled = true },
+        };
+    }
+
+    private async Task ToggleAgent(AgentModel agent, bool newValue)
+    {
+        var previousValue = agent.IsEnabled;
+        
+        try
+        {
+            agent.IsEnabled = newValue;
+            
+            await SaveAgentSettings(agent);
+            
+            ShowSuccessMessage(newValue 
+                ? $"Agent「{agent.Name}」已成功啟用" 
+                : $"Agent「{agent.Name}」已成功停用");
+        }
+        catch (Exception ex)
+        {
+            agent.IsEnabled = previousValue;
+            ShowErrorMessage($"切換 Agent「{agent.Name}」狀態時發生錯誤：{ex.Message}");
+        }
+    }
+
+    private async Task SaveAgentSettings(AgentModel agent)
+    {
+        await Task.Delay(100);
+    }
+
+    private void ShowSuccessMessage(string message)
+    {
+        ShowMessage(message, true);
+    }
+
+    private void ShowErrorMessage(string message)
+    {
+        ShowMessage(message, false);
+    }
+
+    private void ShowMessage(string message, bool isSuccess)
+    {
+        _dismissTimer?.Dispose();
+        
+        StatusMessage = message;
+        IsSuccess = isSuccess;
+        
+        _dismissTimer = new Timer(3000);
+        _dismissTimer.Elapsed += async (_, _) =>
+        {
+            _dismissTimer?.Dispose();
+            _dismissTimer = null;
+            StatusMessage = string.Empty;
+            await InvokeAsync(StateHasChanged);
+        };
+        _dismissTimer.AutoReset = false;
+        _dismissTimer.Start();
+        
+        StateHasChanged();
+    }
+
+    private void ClearStatusMessage()
+    {
+        _dismissTimer?.Dispose();
+        _dismissTimer = null;
+        StatusMessage = string.Empty;
+    }
+
+    public void Dispose()
+    {
+        _dismissTimer?.Dispose();
+    }
+
+    public class AgentModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public bool IsEnabled { get; set; }
+    }
+}
+```

--- a/AiTeam/Pages/AgentSettings.razor.cs
+++ b/AiTeam/Pages/AgentSettings.razor.cs
@@ -1,0 +1,149 @@
+
+```csharp
+using Microsoft.AspNetCore.Components;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AiTeam.Pages
+{
+    public partial class AgentSettings : ComponentBase
+    {
+        // Agent model
+        public class Agent
+        {
+            public int Id { get; set; }
+            public string Name { get; set; } = string.Empty;
+            public string Description { get; set; } = string.Empty;
+            public bool IsEnabled { get; set; }
+        }
+
+        // Notification model for displaying messages
+        public class Notification
+        {
+            public string Message { get; set; } = string.Empty;
+            public string Type { get; set; } = "info"; // info, success, warning, error
+            public bool IsVisible { get; set; }
+            public int? AgentId { get; set; } // Track which agent triggered the notification
+        }
+
+        // Current notification state
+        public Notification CurrentNotification { get; set; } = new Notification();
+
+        // List of agents
+        public List<Agent> Agents { get; set; } = new List<Agent>();
+
+        // Loading state
+        public bool IsLoading { get; set; }
+
+        protected override async Task OnInitializedAsync()
+        {
+            await LoadAgentsAsync();
+        }
+
+        public async Task LoadAgentsAsync()
+        {
+            IsLoading = true;
+            
+            // Simulate loading agents
+            await Task.Delay(10); // Minimal delay for async operation
+            
+            Agents = new List<Agent>
+            {
+                new Agent { Id = 1, Name = "Customer Service Agent", Description = "Handles customer inquiries", IsEnabled = true },
+                new Agent { Id = 2, Name = "Sales Agent", Description = "Manages sales processes", IsEnabled = false },
+                new Agent { Id = 3, Name = "Technical Support Agent", Description = "Provides technical assistance", IsEnabled = true }
+            };
+            
+            IsLoading = false;
+        }
+
+        public async Task ToggleAgentStatusAsync(Agent agent)
+        {
+            if (agent == null)
+                return;
+
+            var previousStatus = agent.IsEnabled;
+            
+            try
+            {
+                // Toggle the status
+                agent.IsEnabled = !agent.IsEnabled;
+                
+                // Simulate API call
+                await Task.Delay(10);
+                
+                // Show success notification near the toggle button
+                ShowNotification(
+                    agent.IsEnabled 
+                        ? $"Agent '{agent.Name}' has been enabled successfully." 
+                        : $"Agent '{agent.Name}' has been disabled successfully.",
+                    "success",
+                    agent.Id
+                );
+            }
+            catch (Exception ex)
+            {
+                // Revert on error
+                agent.IsEnabled = previousStatus;
+                
+                ShowNotification(
+                    $"Failed to update agent status: {ex.Message}",
+                    "error",
+                    agent.Id
+                );
+            }
+        }
+
+        public void ShowNotification(string message, string type = "info", int? agentId = null)
+        {
+            CurrentNotification = new Notification
+            {
+                Message = message,
+                Type = type,
+                IsVisible = true,
+                AgentId = agentId
+            };
+
+            // Auto-hide notification after delay
+            _ = AutoHideNotificationAsync();
+        }
+
+        public async Task AutoHideNotificationAsync()
+        {
+            await Task.Delay(3000);
+            HideNotification();
+            StateHasChanged();
+        }
+
+        public void HideNotification()
+        {
+            CurrentNotification.IsVisible = false;
+        }
+
+        public string GetNotificationCssClass()
+        {
+            return CurrentNotification.Type switch
+            {
+                "success" => "notification notification-success",
+                "error" => "notification notification-error",
+                "warning" => "notification notification-warning",
+                _ => "notification notification-info"
+            };
+        }
+
+        public bool IsNotificationVisibleForAgent(int agentId)
+        {
+            return CurrentNotification.IsVisible && 
+                   CurrentNotification.AgentId.HasValue && 
+                   CurrentNotification.AgentId.Value == agentId;
+        }
+
+        public bool IsGlobalNotificationVisible()
+        {
+            return CurrentNotification.IsVisible && 
+                   !CurrentNotification.AgentId.HasValue;
+        }
+    }
+}
+```

--- a/AiTeam/wwwroot/css/agent-settings.css
+++ b/AiTeam/wwwroot/css/agent-settings.css
@@ -1,0 +1,291 @@
+
+```css
+/* Agent Settings Page Styles */
+
+.agent-settings-container {
+    padding: 1.5rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.agent-settings-header {
+    margin-bottom: 2rem;
+}
+
+.agent-settings-header h1 {
+    font-size: 1.75rem;
+    font-weight: 600;
+    color: #1a1a2e;
+}
+
+/* Agent Card Styles */
+.agent-card {
+    position: relative;
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    margin-bottom: 1rem;
+    transition: box-shadow 0.2s ease;
+}
+
+.agent-card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.agent-card.disabled {
+    opacity: 0.7;
+    background: #f8fafc;
+}
+
+/* Toggle Switch Area */
+.agent-toggle-area {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+/* Notification/Toast Message Styles */
+.agent-notification {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    z-index: 100;
+    min-width: 200px;
+    max-width: 320px;
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    animation: fadeInDown 0.25s ease forwards;
+    pointer-events: none;
+    white-space: nowrap;
+}
+
+.agent-notification.success {
+    background-color: #d1fae5;
+    color: #065f46;
+    border: 1px solid #6ee7b7;
+}
+
+.agent-notification.error {
+    background-color: #fee2e2;
+    color: #991b1b;
+    border: 1px solid #fca5a5;
+}
+
+.agent-notification.warning {
+    background-color: #fef3c7;
+    color: #92400e;
+    border: 1px solid #fcd34d;
+}
+
+.agent-notification.info {
+    background-color: #dbeafe;
+    color: #1e40af;
+    border: 1px solid #93c5fd;
+}
+
+/* Notification positioned near toggle button */
+.toggle-notification-wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+}
+
+.toggle-notification-wrapper .agent-notification {
+    top: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+/* Global notification area at the top of settings page */
+.agent-settings-notification-area {
+    position: sticky;
+    top: 0;
+    z-index: 200;
+    padding: 0.5rem 0;
+    margin-bottom: 1rem;
+}
+
+.agent-settings-notification-area .agent-notification {
+    position: relative;
+    top: auto;
+    left: auto;
+    max-width: 100%;
+    width: 100%;
+    animation: fadeInDown 0.25s ease forwards;
+}
+
+/* Toggle Switch Styles */
+.toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 48px;
+    height: 26px;
+}
+
+.toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #cbd5e1;
+    transition: 0.3s;
+    border-radius: 26px;
+}
+
+.toggle-slider:before {
+    position: absolute;
+    content: "";
+    height: 20px;
+    width: 20px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    transition: 0.3s;
+    border-radius: 50%;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-switch input:checked + .toggle-slider {
+    background-color: #3b82f6;
+}
+
+.toggle-switch input:checked + .toggle-slider:before {
+    transform: translateX(22px);
+}
+
+.toggle-switch input:disabled + .toggle-slider {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+/* Toggle label text */
+.toggle-label {
+    font-size: 0.875rem;
+    color: #64748b;
+    font-weight: 500;
+    user-select: none;
+}
+
+.toggle-label.enabled {
+    color: #059669;
+}
+
+.toggle-label.disabled {
+    color: #94a3b8;
+}
+
+/* Agent Status Badge */
+.agent-status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.agent-status-badge.active {
+    background-color: #d1fae5;
+    color: #065f46;
+}
+
+.agent-status-badge.inactive {
+    background-color: #f1f5f9;
+    color: #64748b;
+}
+
+/* Animations */
+@keyframes fadeInDown {
+    from {
+        opacity: 0;
+        transform: translateY(-8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes fadeOut {
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+    }
+}
+
+.agent-notification.fade-out {
+    animation: fadeOut 0.3s ease forwards;
+}
+
+/* Responsive adjustments */
+@media (max-width: 640px) {
+    .agent-settings-container {
+        padding: 1rem;
+    }
+
+    .agent-notification {
+        max-width: 280px;
+        font-size: 0.8125rem;
+    }
+
+    .toggle-notification-wrapper .agent-notification {
+        left: 0;
+        transform: none;
+    }
+}
+
+/* Accessibility */
+.toggle-switch:focus-within .toggle-slider {
+    outline: 2px solid #3b82f6;
+    outline-offset: 2px;
+}
+
+.agent-notification[role="alert"] {
+    pointer-events: auto;
+}
+
+/* Loading state for toggle */
+.toggle-switch.loading .toggle-slider {
+    cursor: wait;
+    opacity: 0.7;
+}
+
+.toggle-switch.loading .toggle-slider:after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 12px;
+    height: 12px;
+    margin-top: -6px;
+    margin-left: -6px;
+    border: 2px solid rgba(255, 255, 255, 0.6);
+    border-top-color: white;
+    border-radius: 50%;
+    animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+```


### PR DESCRIPTION
## 任務說明
修復 Agent 設定頁面啟用/停用提示訊息顯示位置

## 變更摘要
修復 Agent 設定頁面中，切換啟用/停用狀態時提示訊息顯示位置不正確的問題。將檢查 AgentSettings.razor 元件內提示訊息的渲染位置與 CSS 定位邏輯，確保訊息顯示於正確的 UI 區塊（如切換按鈕附近或統一的通知區域），並補充對應的 xUnit 測試驗證訊息出現的條件與位置。

## 修改檔案
- AiTeam/Pages/AgentSettings.razor
- AiTeam/Pages/AgentSettings.razor.cs
- AiTeam/wwwroot/css/agent-settings.css
- AiTeam.Tests/Pages/AgentSettingsTests.cs

---
🤖 由 AiTeam Dev Agent 自動產出