### PR TITLE
test: QA 自動測試（PR #35）

### DIFF
--- a/src/AiTeam.Tests.Playwright/Generated/PR35/VisualTests.cs
+++ b/src/AiTeam.Tests.Playwright/Generated/PR35/VisualTests.cs
@@ -1,0 +1,288 @@
+using Microsoft.Playwright.MSTest;
+using Microsoft.Playwright;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace AiTeam.Tests.Playwright.Generated
+{
+    [TestClass]
+    public class PR35_ReviewerAgent頁面視覺截圖測試 : PageTest
+    {
+        private string _dashboardUrl = string.Empty;
+        private string _screenshotDir = string.Empty;
+
+        [TestInitialize]
+        public async Task 測試初始化()
+        {
+            _dashboardUrl = Environment.GetEnvironmentVariable("DASHBOARD_URL") ?? "http://localhost:5051";
+            _screenshotDir = Path.Combine("screenshots", "PR35_ReviewerAgent");
+            Directory.CreateDirectory(_screenshotDir);
+
+            var user = Environment.GetEnvironmentVariable("DASHBOARD_USER") ?? string.Empty;
+            var pass = Environment.GetEnvironmentVariable("DASHBOARD_PASS") ?? string.Empty;
+
+            if (!string.IsNullOrEmpty(user) && !string.IsNullOrEmpty(pass))
+            {
+                await Page.GotoAsync($"{_dashboardUrl}/login");
+                await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+                var userInput = Page.Locator("input[type='text'], input[name='username'], input[id='username'], input[placeholder*='user' i], input[placeholder*='帳號']").First;
+                var passInput = Page.Locator("input[type='password']").First;
+
+                await userInput.FillAsync(user);
+                await passInput.FillAsync(pass);
+
+                await Page.Locator("button[type='submit'], button:has-text('登入'), button:has-text('Login')").First.ClickAsync();
+                await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            }
+        }
+
+        [TestMethod]
+        public async Task ReviewerAgent頁面_Light模式_截圖驗證()
+        {
+            var targetUrl = $"{_dashboardUrl}/reviewer-agent";
+            await Page.GotoAsync(targetUrl);
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var screenshotPath = Path.Combine(_screenshotDir, "ReviewerAgent_light.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"Light 模式截圖應存在：{screenshotPath}");
+            var fileInfo = new FileInfo(screenshotPath);
+            Assert.IsTrue(fileInfo.Length > 0, "Light 模式截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task ReviewerAgent頁面_Dark模式_截圖驗證()
+        {
+            var targetUrl = $"{_dashboardUrl}/reviewer-agent";
+            await Page.GotoAsync(targetUrl);
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var darkModeToggle = Page.Locator(
+                "button[aria-label*='dark' i], button[aria-label*='Dark' i], " +
+                "button[aria-label*='theme' i], button[aria-label*='Theme' i], " +
+                "input[type='checkbox'][aria-label*='dark' i], " +
+                ".dark-mode-toggle, #darkModeToggle, [data-testid='dark-mode-toggle'], " +
+                "button:has-text('Dark'), button:has-text('dark'), " +
+                "button:has-text('夜間'), button:has-text('深色')"
+            ).First;
+
+            var toggleVisible = await darkModeToggle.IsVisibleAsync();
+            if (toggleVisible)
+            {
+                await darkModeToggle.ClickAsync();
+                await Page.WaitForTimeoutAsync(800);
+            }
+            else
+            {
+                await Page.EvaluateAsync(@"
+                    document.documentElement.classList.add('dark');
+                    document.body.classList.add('dark');
+                    document.body.setAttribute('data-theme', 'dark');
+                ");
+                await Page.WaitForTimeoutAsync(800);
+            }
+
+            var screenshotPath = Path.Combine(_screenshotDir, "ReviewerAgent_dark.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"Dark 模式截圖應存在：{screenshotPath}");
+            var fileInfo = new FileInfo(screenshotPath);
+            Assert.IsTrue(fileInfo.Length > 0, "Dark 模式截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task ReviewerAgent頁面_驗證頁面標題與主要內容存在()
+        {
+            var targetUrl = $"{_dashboardUrl}/reviewer-agent";
+            await Page.GotoAsync(targetUrl);
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var pageTitle = await Page.TitleAsync();
+            Assert.IsFalse(string.IsNullOrEmpty(pageTitle), "頁面標題不應為空");
+
+            var bodyContent = await Page.Locator("body").InnerTextAsync();
+            Assert.IsFalse(string.IsNullOrEmpty(bodyContent), "頁面主體內容不應為空");
+
+            var screenshotPath = Path.Combine(_screenshotDir, "ReviewerAgent_內容驗證.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"內容驗證截圖應存在：{screenshotPath}");
+        }
+
+        [TestMethod]
+        public async Task ReviewerAgent頁面_驗證無主控台錯誤_Light模式()
+        {
+            var consoleErrors = new System.Collections.Generic.List<string>();
+            Page.Console += (_, msg) =>
+            {
+                if (msg.Type == "error")
+                {
+                    consoleErrors.Add(msg.Text);
+                }
+            };
+
+            var targetUrl = $"{_dashboardUrl}/reviewer-agent";
+            await Page.GotoAsync(targetUrl);
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(2000);
+
+            var screenshotPath = Path.Combine(_screenshotDir, "ReviewerAgent_無錯誤驗證_light.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"無錯誤驗證截圖應存在：{screenshotPath}");
+
+            if (consoleErrors.Count > 0)
+            {
+                Console.WriteLine($"偵測到主控台錯誤（共 {consoleErrors.Count} 筆）：");
+                foreach (var error in consoleErrors)
+                {
+                    Console.WriteLine($"  - {error}");
+                }
+            }
+
+            Assert.AreEqual(0, consoleErrors.Count, $"頁面不應有主控台錯誤，實際錯誤：{string.Join("; ", consoleErrors)}");
+        }
+
+        [TestMethod]
+        public async Task ReviewerAgent頁面_驗證無主控台錯誤_Dark模式()
+        {
+            var consoleErrors = new System.Collections.Generic.List<string>();
+            Page.Console += (_, msg) =>
+            {
+                if (msg.Type == "error")
+                {
+                    consoleErrors.Add(msg.Text);
+                }
+            };
+
+            var targetUrl = $"{_dashboardUrl}/reviewer-agent";
+            await Page.GotoAsync(targetUrl);
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var darkModeToggle = Page.Locator(
+                "button[aria-label*='dark' i], button[aria-label*='Dark' i], " +
+                "button[aria-label*='theme' i], button[aria-label*='Theme' i], " +
+                "input[type='checkbox'][aria-label*='dark' i], " +
+                ".dark-mode-toggle, #darkModeToggle, [data-testid='dark-mode-toggle'], " +
+                "button:has-text('Dark'), button:has-text('dark'), " +
+                "button:has-text('夜間'), button:has-text('深色')"
+            ).First;
+
+            var toggleVisible = await darkModeToggle.IsVisibleAsync();
+            if (toggleVisible)
+            {
+                await darkModeToggle.ClickAsync();
+                await Page.WaitForTimeoutAsync(800);
+            }
+            else
+            {
+                await Page.EvaluateAsync(@"
+                    document.documentElement.classList.add('dark');
+                    document.body.classList.add('dark');
+                    document.body.setAttribute('data-theme', 'dark');
+                ");
+                await Page.WaitForTimeoutAsync(800);
+            }
+
+            var screenshotPath = Path.Combine(_screenshotDir, "ReviewerAgent_無錯誤驗證_dark.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"Dark 模式無錯誤驗證截圖應存在：{screenshotPath}");
+
+            if (consoleErrors.Count > 0)
+            {
+                Console.WriteLine($"偵測到主控台錯誤（共 {consoleErrors.Count} 筆）：");
+                foreach (var error in consoleErrors)
+                {
+                    Console.WriteLine($"  - {error}");
+                }
+            }
+
+            Assert.AreEqual(0, consoleErrors.Count, $"Dark 模式頁面不應有主控台錯誤，實際錯誤：{string.Join("; ", consoleErrors)}");
+        }
+
+        [TestMethod]
+        public async Task ReviewerAgent頁面_行動裝置版面_截圖驗證()
+        {
+            await Page.SetViewportSizeAsync(390, 844);
+
+            var targetUrl = $"{_dashboardUrl}/reviewer-agent";
+            await Page.GotoAsync(targetUrl);
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var screenshotPath = Path.Combine(_screenshotDir, "ReviewerAgent_mobile_light.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"行動裝置 Light 模式截圖應存在：{screenshotPath}");
+            var fileInfo = new FileInfo(screenshotPath);
+            Assert.IsTrue(fileInfo.Length > 0, "行動裝置截圖檔案不應為空");
+
+            var darkModeToggle = Page.Locator(
+                "button[aria-label*='dark' i], button[aria-label*='Dark' i], " +
+                "button[aria-label*='theme' i], button[aria-label*='Theme' i], " +
+                ".dark-mode-toggle, #darkModeToggle, [data-testid='dark-mode-toggle'], " +
+                "button:has-text('Dark'), button:has-text('夜間'), button:has-text('深色')"
+            ).First;
+
+            var toggleVisible = await darkModeToggle.IsVisibleAsync();
+            if (toggleVisible)
+            {
+                await darkModeToggle.ClickAsync();
+                await Page.WaitForTimeoutAsync(800);
+            }
+            else
+            {
+                await Page.EvaluateAsync(@"
+                    document.documentElement.classList.add('dark');
+                    document.body.classList.add('dark');
+                    document.body.setAttribute('data-theme', 'dark');
+                ");
+                await Page.WaitForTimeoutAsync(800);
+            }
+
+            var darkScreenshotPath = Path.Combine(_screenshotDir, "ReviewerAgent_mobile_dark.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path = darkScreenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(darkScreenshotPath), $"行動裝置 Dark 模式截圖應存在：{darkScreenshotPath}");
+            var darkFileInfo = new FileInfo(darkScreenshotPath);
+            Assert.IsTrue(darkFileInfo.Length > 0, "行動裝置 Dark 模式截圖檔案不應為空");
+        }
+    }
+}

--- a/tests/Generated/src/AiTeam.Bot/Agents/ReviewerAgentTests.cs
+++ b/tests/Generated/src/AiTeam.Bot/Agents/ReviewerAgentTests.cs
@@ -1,0 +1,479 @@
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+using AiTeam.Bot.Agents;
+
+namespace AiTeam.Bot.Tests.Agents
+{
+    // ===== ReviewIssue Tests =====
+    public class ReviewIssueTests
+    {
+        [Fact]
+        public void ReviewIssue_預設建立_所有字串屬性應為空字串()
+        {
+            // Arrange & Act
+            var issue = new ReviewIssue();
+
+            // Assert
+            issue.Type.Should().BeEmpty();
+            issue.Severity.Should().BeEmpty();
+            issue.Description.Should().BeEmpty();
+            issue.FilePath.Should().BeEmpty();
+            issue.LineNumber.Should().BeNull();
+            issue.Suggestion.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ReviewIssue_設定所有屬性_應正確儲存()
+        {
+            // Arrange & Act
+            var issue = new ReviewIssue
+            {
+                Type = "Bug",
+                Severity = "High",
+                Description = "空指標參考",
+                FilePath = "src/Program.cs",
+                LineNumber = 42,
+                Suggestion = "請加入 null 檢查"
+            };
+
+            // Assert
+            issue.Type.Should().Be("Bug");
+            issue.Severity.Should().Be("High");
+            issue.Description.Should().Be("空指標參考");
+            issue.FilePath.Should().Be("src/Program.cs");
+            issue.LineNumber.Should().Be(42);
+            issue.Suggestion.Should().Be("請加入 null 檢查");
+        }
+    }
+
+    // ===== ReviewIssueSummary Tests =====
+    public class ReviewIssueSummaryTests
+    {
+        [Fact]
+        public void RenderStatisticsRow_有各類型問題_應渲染包含所有類型的表格()
+        {
+            // Arrange
+            var summary = new ReviewIssueSummary
+            {
+                BugCount = 2,
+                WarningCount = 3,
+                InfoCount = 1,
+                TotalCount = 6,
+                IssueCountByType = new Dictionary<string, int>
+                {
+                    { "Bug", 2 },
+                    { "Warning", 3 },
+                    { "Info", 1 }
+                }
+            };
+
+            // Act
+            var result = summary.RenderStatisticsRow();
+
+            // Assert
+            result.Should().Contain("## 問題總結統計");
+            result.Should().Contain("🐛 Bug");
+            result.Should().Contain("⚠️ Warning");
+            result.Should().Contain("ℹ️ Info");
+            result.Should().Contain("**總計**");
+            result.Should().Contain("**6**");
+        }
+
+        [Fact]
+        public void RenderStatisticsRow_包含未知類型_應使用預設emoji()
+        {
+            // Arrange
+            var summary = new ReviewIssueSummary
+            {
+                TotalCount = 1,
+                IssueCountByType = new Dictionary<string, int>
+                {
+                    { "CustomType", 1 }
+                }
+            };
+
+            // Act
+            var result = summary.RenderStatisticsRow();
+
+            // Assert
+            result.Should().Contain("📌 CustomType");
+        }
+
+        [Fact]
+        public void RenderStatisticsRow_包含Error類型_應使用錯誤emoji()
+        {
+            // Arrange
+            var summary = new ReviewIssueSummary
+            {
+                TotalCount = 1,
+                IssueCountByType = new Dictionary<string, int>
+                {
+                    { "error", 1 }
+                }
+            };
+
+            // Act
+            var result = summary.RenderStatisticsRow();
+
+            // Assert
+            result.Should().Contain("❌ error");
+        }
+
+        [Fact]
+        public void RenderStatisticsRow_包含Suggestion類型_應使用燈泡emoji()
+        {
+            // Arrange
+            var summary = new ReviewIssueSummary
+            {
+                TotalCount = 1,
+                IssueCountByType = new Dictionary<string, int>
+                {
+                    { "suggestion", 1 }
+                }
+            };
+
+            // Act
+            var result = summary.RenderStatisticsRow();
+
+            // Assert
+            result.Should().Contain("💡 suggestion");
+        }
+
+        [Fact]
+        public void RenderStatisticsRow_問題依數量降序排列_數量多的類型應排前面()
+        {
+            // Arrange
+            var summary = new ReviewIssueSummary
+            {
+                TotalCount = 6,
+                IssueCountByType = new Dictionary<string, int>
+                {
+                    { "Info", 1 },
+                    { "Bug", 5 }
+                }
+            };
+
+            // Act
+            var result = summary.RenderStatisticsRow();
+
+            // Assert
+            var bugIndex = result.IndexOf("Bug", StringComparison.Ordinal);
+            var infoIndex = result.IndexOf("Info", StringComparison.Ordinal);
+            bugIndex.Should().BeLessThan(infoIndex);
+        }
+
+        [Fact]
+        public void RenderStatisticsRow_空IssueCountByType_應僅渲染總計行()
+        {
+            // Arrange
+            var summary = new ReviewIssueSummary
+            {
+                TotalCount = 0,
+                IssueCountByType = new Dictionary<string, int>()
+            };
+
+            // Act
+            var result = summary.RenderStatisticsRow();
+
+            // Assert
+            result.Should().Contain("**總計**");
+            result.Should().Contain("**0**");
+        }
+    }
+
+    // ===== ReviewReport Tests =====
+    public class ReviewReportTests
+    {
+        private ReviewReport CreateReportWithIssues(List<ReviewIssue>? issues = null)
+        {
+            var report = new ReviewReport
+            {
+                Title = "測試報告",
+                Summary = "這是測試摘要",
+                OverallAssessment = "整體良好",
+                Recommendations = "建議加強測試",
+                Issues = issues ?? new List<ReviewIssue>()
+            };
+            return report;
+        }
+
+        [Fact]
+        public void CalculateStatistics_有多種類型問題_應正確計算各類型數量()
+        {
+            // Arrange
+            var report = CreateReportWithIssues(new List<ReviewIssue>
+            {
+                new ReviewIssue { Type = "Bug" },
+                new ReviewIssue { Type = "Bug" },
+                new ReviewIssue { Type = "Warning" },
+                new ReviewIssue { Type = "Info" }
+            });
+
+            // Act
+            report.CalculateStatistics();
+
+            // Assert
+            report.IssueSummary.BugCount.Should().Be(2);
+            report.IssueSummary.WarningCount.Should().Be(1);
+            report.IssueSummary.InfoCount.Should().Be(1);
+            report.IssueSummary.TotalCount.Should().Be(4);
+            report.IssueSummary.IssueCountByType["Bug"].Should().Be(2);
+            report.IssueSummary.IssueCountByType["Warning"].Should().Be(1);
+            report.IssueSummary.IssueCountByType["Info"].Should().Be(1);
+        }
+
+        [Fact]
+        public void CalculateStatistics_問題清單為空_應所有計數為零()
+        {
+            // Arrange
+            var report = CreateReportWithIssues(new List<ReviewIssue>());
+
+            // Act
+            report.CalculateStatistics();
+
+            // Assert
+            report.IssueSummary.BugCount.Should().Be(0);
+            report.IssueSummary.WarningCount.Should().Be(0);
+            report.IssueSummary.InfoCount.Should().Be(0);
+            report.IssueSummary.TotalCount.Should().Be(0);
+            report.IssueSummary.IssueCountByType.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void CalculateStatistics_問題Type為空白字串_應歸類為Other()
+        {
+            // Arrange
+            var report = CreateReportWithIssues(new List<ReviewIssue>
+            {
+                new ReviewIssue { Type = "" },
+                new ReviewIssue { Type = "   " }
+            });
+
+            // Act
+            report.CalculateStatistics();
+
+            // Assert
+            report.IssueSummary.IssueCountByType.Should().ContainKey("Other");
+            report.IssueSummary.IssueCountByType["Other"].Should().Be(2);
+        }
+
+        [Fact]
+        public void CalculateStatistics_重複計算_應重置並重新計算()
+        {
+            // Arrange
+            var report = CreateReportWithIssues(new List<ReviewIssue>
+            {
+                new ReviewIssue { Type = "Bug" }
+            });
+
+            // Act - 計算兩次
+            report.CalculateStatistics();
+            report.CalculateStatistics();
+
+            // Assert - 計數不應翻倍
+            report.IssueSummary.BugCount.Should().Be(1);
+            report.IssueSummary.TotalCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void RenderReport_有完整資料_應包含所有區段()
+        {
+            // Arrange
+            var report = CreateReportWithIssues(new List<ReviewIssue>
+            {
+                new ReviewIssue
+                {
+                    Type = "Bug",
+                    Description = "空指標",
+                    FilePath = "src/Program.cs",
+                    LineNumber = 10,
+                    Suggestion = "加入 null 檢查"
+                }
+            });
+            report.CalculateStatistics();
+
+            // Act
+            var result = report.RenderReport();
+
+            // Assert
+            result.Should().Contain("# 測試報告");
+            result.Should().Contain("## 摘要");
+            result.Should().Contain("這是測試摘要");
+            result.Should().Contain("## 發現的問題");
+            result.Should().Contain("空指標");
+            result.Should().Contain("src/Program.cs:10");
+            result.Should().Contain("加入 null 檢查");
+            result.Should().Contain("## 整體評估");
+            result.Should().Contain("整體良好");
+            result.Should().Contain("## 建議事項");
+            result.Should().Contain("建議加強測試");
+        }
+
+        [Fact]
+        public void RenderReport_無問題清單_應不包含發現的問題區段()
+        {
+            // Arrange
+            var report = CreateReportWithIssues(new List<ReviewIssue>());
+            report.CalculateStatistics();
+
+            // Act
+            var result = report.RenderReport();
+
+            // Assert
+            result.Should().NotContain("## 發現的問題");
+            result.Should().NotContain("---");
+        }
+
+        [Fact]
+        public void RenderReport_有問題且統計不為零_應渲染統計區段()
+        {
+            // Arrange
+            var report = CreateReportWithIssues(new List<ReviewIssue>
+            {
+                new ReviewIssue { Type = "Bug", Description = "測試 Bug" }
+            });
+            report.CalculateStatistics();
+
+            // Act
+            var result = report.RenderReport();
+
+            // Assert
+            result.Should().Contain("---");
+            result.Should().Contain("## 問題總結統計");
+        }
+
+        [Fact]
+        public void RenderReport_問題有FilePath但無LineNumber_應只顯示路徑不含行號()
+        {
+            // Arrange
+            var report = CreateReportWithIssues(new List<ReviewIssue>
+            {
+                new ReviewIssue
+                {
+                    Type = "Warning",
+                    Description = "測試問題",
+                    FilePath = "src/Helper.cs",
+                    LineNumber = null
+                }
+            });
+            report.CalculateStatistics();
+
+            // Act
+            var result = report.RenderReport();
+
+            // Assert
+            result.Should().Contain("src/Helper.cs");
+            result.Should().NotContain("src/Helper.cs:");
+        }
+
+        [Fact]
+        public void RenderReport_問題無FilePath_應不顯示位置資訊()
+        {
+            // Arrange
+            var report = CreateReportWithIssues(new List<ReviewIssue>
+            {
+                new ReviewIssue
+                {
+                    Type = "Info",
+                    Description = "只有描述沒有路徑",
+                    FilePath = ""
+                }
+            });
+            report.CalculateStatistics();
+
+            // Act
+            var result = report.RenderReport();
+
+            // Assert
+            result.Should().Contain("只有描述沒有路徑");
+            result.Should().NotContain("**位置：**");
+        }
+
+        [Fact]
+        public void RenderReport_Summary為空_應不包含摘要區段()
+        {
+            // Arrange
+            var report = new ReviewReport
+            {
+                Title = "測試",
+                Summary = "",
+                Issues = new List<ReviewIssue>()
+            };
+            report.CalculateStatistics();
+
+            // Act
+            var result = report.RenderReport();
+
+            // Assert
+            result.Should().NotContain("## 摘要");
+        }
+
+        [Fact]
+        public void RenderReport_OverallAssessment為空_應不包含整體評估區段()
+        {
+            // Arrange
+            var report = new ReviewReport
+            {
+                Title = "測試",
+                OverallAssessment = "",
+                Issues = new List<ReviewIssue>()
+            };
+            report.CalculateStatistics();
+
+            // Act
+            var result = report.RenderReport();
+
+            // Assert
+            result.Should().NotContain("## 整體評估");
+        }
+
+        [Fact]
+        public void RenderReport_Recommendations為空_應不包含建議事項區段()
+        {
+            // Arrange
+            var report = new ReviewReport
+            {
+                Title = "測試",
+                Recommendations = "",
+                Issues = new List<ReviewIssue>()
+            };
+            report.CalculateStatistics();
+
+            // Act
+            var result = report.RenderReport();
+
+            // Assert
+            result.Should().NotContain("## 建議事項");
+        }
+
+        [Fact]
+        public void RenderReport_多種類型問題_應依類型分組顯示()
+        {
+            // Arrange
+            var report = CreateReportWithIssues(new List<ReviewIssue>
+            {
+                new ReviewIssue { Type = "Bug", Description = "Bug 問題" },
+                new ReviewIssue { Type = "Warning", Description = "Warning 問題" },
+                new ReviewIssue { Type = "Bug", Description = "另一個 Bug" }
+            });
+            report.CalculateStatistics();
+
+            // Act
+            var result = report.RenderReport();
+
+            // Assert
+            result.Should().Contain("### Bug");
+            result.Should().Contain("### Warning");
+            result.Should().Contain("Bug 問題");
+            result.Should().Contain("另一個 Bug");
+            result.Should().Contain("Warning 問題");
+        }
+
+        [Fact]
+        public void RenderReport_應包含審查時

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/ReviewerAgent.razorTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/ReviewerAgent.razorTests.cs
@@ -1,0 +1,480 @@
+```csharp
+using AiTeam.Dashboard.Components.Pages;
+using AiTeam.Dashboard.Services;
+using FluentAssertions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using System.Reflection;
+using Xunit;
+
+namespace AiTeam.Dashboard.Tests.Components.Pages;
+
+public class ReviewerAgentTests
+{
+    private readonly IReviewerAgentService _reviewerAgentService;
+    private readonly ReviewerAgent _component;
+
+    public ReviewerAgentTests()
+    {
+        _reviewerAgentService = Substitute.For<IReviewerAgentService>();
+        _component = new ReviewerAgent();
+
+        // 透過反射注入服務
+        var serviceProperty = typeof(ReviewerAgent)
+            .GetProperty("ReviewerAgentService", BindingFlags.NonPublic | BindingFlags.Instance);
+        serviceProperty!.SetValue(_component, _reviewerAgentService);
+    }
+
+    private Task InvokeSubmitReview()
+    {
+        var method = typeof(ReviewerAgent)
+            .GetMethod("SubmitReview", BindingFlags.NonPublic | BindingFlags.Instance);
+        return (Task)method!.Invoke(_component, null)!;
+    }
+
+    private void InvokeClearInput()
+    {
+        var method = typeof(ReviewerAgent)
+            .GetMethod("ClearInput", BindingFlags.NonPublic | BindingFlags.Instance);
+        method!.Invoke(_component, null);
+    }
+
+    private void SetCodeInput(string value)
+    {
+        var field = typeof(ReviewerAgent)
+            .GetField("_codeInput", BindingFlags.NonPublic | BindingFlags.Instance);
+        field!.SetValue(_component, value);
+    }
+
+    private string? GetErrorMessage()
+    {
+        var field = typeof(ReviewerAgent)
+            .GetField("_errorMessage", BindingFlags.NonPublic | BindingFlags.Instance);
+        return (string?)field!.GetValue(_component);
+    }
+
+    private ReviewReport? GetReviewReport()
+    {
+        var field = typeof(ReviewerAgent)
+            .GetField("_reviewReport", BindingFlags.NonPublic | BindingFlags.Instance);
+        return (ReviewReport?)field!.GetValue(_component);
+    }
+
+    private bool GetIsLoading()
+    {
+        var field = typeof(ReviewerAgent)
+            .GetField("_isLoading", BindingFlags.NonPublic | BindingFlags.Instance);
+        return (bool)field!.GetValue(_component)!;
+    }
+
+    #region SubmitReview Tests
+
+    [Fact]
+    public async Task SubmitReview_輸入有效程式碼_應回傳審查報告()
+    {
+        // Arrange
+        var expectedReport = new ReviewReport
+        {
+            Summary = "程式碼品質良好",
+            OverallScore = 85,
+            Issues = new List<ReviewIssue>
+            {
+                new ReviewIssue { Severity = "warning", Message = "建議命名改善" }
+            }
+        };
+
+        SetCodeInput("var x = 1;");
+        _reviewerAgentService.ReviewCodeAsync(Arg.Any<string>()).Returns(expectedReport);
+
+        // Act
+        await InvokeSubmitReview();
+
+        // Assert
+        var report = GetReviewReport();
+        report.Should().NotBeNull();
+        report!.Summary.Should().Be("程式碼品質良好");
+        report.OverallScore.Should().Be(85);
+        GetIsLoading().Should().BeFalse();
+        GetErrorMessage().Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SubmitReview_輸入空白字串_應設置錯誤訊息且不呼叫服務()
+    {
+        // Arrange
+        SetCodeInput("   ");
+
+        // Act
+        await InvokeSubmitReview();
+
+        // Assert
+        GetErrorMessage().Should().Be("請輸入要審查的程式碼");
+        GetReviewReport().Should().BeNull();
+        await _reviewerAgentService.DidNotReceive().ReviewCodeAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task SubmitReview_輸入空字串_應設置錯誤訊息且不呼叫服務()
+    {
+        // Arrange
+        SetCodeInput(string.Empty);
+
+        // Act
+        await InvokeSubmitReview();
+
+        // Assert
+        GetErrorMessage().Should().Be("請輸入要審查的程式碼");
+        GetReviewReport().Should().BeNull();
+        await _reviewerAgentService.DidNotReceive().ReviewCodeAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task SubmitReview_服務拋出例外_應設置錯誤訊息()
+    {
+        // Arrange
+        SetCodeInput("var x = 1;");
+        _reviewerAgentService.ReviewCodeAsync(Arg.Any<string>())
+            .Throws(new Exception("連線逾時"));
+
+        // Act
+        await InvokeSubmitReview();
+
+        // Assert
+        GetErrorMessage().Should().Be("審查過程發生錯誤：連線逾時");
+        GetReviewReport().Should().BeNull();
+        GetIsLoading().Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SubmitReview_呼叫服務時_應傳入正確的程式碼內容()
+    {
+        // Arrange
+        var codeContent = "public void Test() { }";
+        SetCodeInput(codeContent);
+        _reviewerAgentService.ReviewCodeAsync(Arg.Any<string>()).Returns(new ReviewReport());
+
+        // Act
+        await InvokeSubmitReview();
+
+        // Assert
+        await _reviewerAgentService.Received(1).ReviewCodeAsync(codeContent);
+    }
+
+    [Fact]
+    public async Task SubmitReview_成功執行後_載入狀態應為false()
+    {
+        // Arrange
+        SetCodeInput("int a = 1;");
+        _reviewerAgentService.ReviewCodeAsync(Arg.Any<string>()).Returns(new ReviewReport());
+
+        // Act
+        await InvokeSubmitReview();
+
+        // Assert
+        GetIsLoading().Should().BeFalse();
+    }
+
+    #endregion
+
+    #region ClearInput Tests
+
+    [Fact]
+    public void ClearInput_清除後_所有欄位應重置為預設值()
+    {
+        // Arrange
+        SetCodeInput("some code");
+        var reportField = typeof(ReviewerAgent)
+            .GetField("_reviewReport", BindingFlags.NonPublic | BindingFlags.Instance);
+        reportField!.SetValue(_component, new ReviewReport());
+
+        var errorField = typeof(ReviewerAgent)
+            .GetField("_errorMessage", BindingFlags.NonPublic | BindingFlags.Instance);
+        errorField!.SetValue(_component, "some error");
+
+        // Act
+        InvokeClearInput();
+
+        // Assert
+        var codeField = typeof(ReviewerAgent)
+            .GetField("_codeInput", BindingFlags.NonPublic | BindingFlags.Instance);
+        var codeValue = (string?)codeField!.GetValue(_component);
+
+        codeValue.Should().BeEmpty();
+        GetReviewReport().Should().BeNull();
+        GetErrorMessage().Should().BeNull();
+    }
+
+    [Fact]
+    public void ClearInput_已有審查結果時清除_審查報告應為null()
+    {
+        // Arrange
+        var reportField = typeof(ReviewerAgent)
+            .GetField("_reviewReport", BindingFlags.NonPublic | BindingFlags.Instance);
+        reportField!.SetValue(_component, new ReviewReport { Summary = "測試摘要", OverallScore = 90 });
+
+        // Act
+        InvokeClearInput();
+
+        // Assert
+        GetReviewReport().Should().BeNull();
+    }
+
+    #endregion
+}
+
+public class ReviewReportTests
+{
+    #region CalculateStatistics Tests
+
+    [Fact]
+    public void Statistics_空的問題列表_所有計數應為零()
+    {
+        // Arrange
+        var report = new ReviewReport
+        {
+            Issues = new List<ReviewIssue>()
+        };
+
+        // Act
+        var stats = report.Statistics;
+
+        // Assert
+        stats.TotalCount.Should().Be(0);
+        stats.BugCount.Should().Be(0);
+        stats.WarningCount.Should().Be(0);
+        stats.InfoCount.Should().Be(0);
+        stats.SuggestionCount.Should().Be(0);
+        stats.OtherCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Statistics_包含多種嚴重程度的問題_計數應正確()
+    {
+        // Arrange
+        var report = new ReviewReport
+        {
+            Issues = new List<ReviewIssue>
+            {
+                new ReviewIssue { Severity = "bug" },
+                new ReviewIssue { Severity = "error" },
+                new ReviewIssue { Severity = "warning" },
+                new ReviewIssue { Severity = "info" },
+                new ReviewIssue { Severity = "information" },
+                new ReviewIssue { Severity = "suggestion" },
+                new ReviewIssue { Severity = "unknown" }
+            }
+        };
+
+        // Act
+        var stats = report.Statistics;
+
+        // Assert
+        stats.TotalCount.Should().Be(7);
+        stats.BugCount.Should().Be(2);
+        stats.WarningCount.Should().Be(1);
+        stats.InfoCount.Should().Be(2);
+        stats.SuggestionCount.Should().Be(1);
+        stats.OtherCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Statistics_嚴重程度大寫_應正確分類()
+    {
+        // Arrange
+        var report = new ReviewReport
+        {
+            Issues = new List<ReviewIssue>
+            {
+                new ReviewIssue { Severity = "BUG" },
+                new ReviewIssue { Severity = "WARNING" },
+                new ReviewIssue { Severity = "INFO" }
+            }
+        };
+
+        // Act
+        var stats = report.Statistics;
+
+        // Assert
+        stats.BugCount.Should().Be(1);
+        stats.WarningCount.Should().Be(1);
+        stats.InfoCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Statistics_嚴重程度為null_應計入OtherCount()
+    {
+        // Arrange
+        var report = new ReviewReport
+        {
+            Issues = new List<ReviewIssue>
+            {
+                new ReviewIssue { Severity = null! }
+            }
+        };
+
+        // Act
+        var stats = report.Statistics;
+
+        // Assert
+        stats.OtherCount.Should().Be(1);
+        stats.TotalCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Statistics_多個Bug問題_BugCount應正確累計()
+    {
+        // Arrange
+        var report = new ReviewReport
+        {
+            Issues = new List<ReviewIssue>
+            {
+                new ReviewIssue { Severity = "bug" },
+                new ReviewIssue { Severity = "bug" },
+                new ReviewIssue { Severity = "error" }
+            }
+        };
+
+        // Act
+        var stats = report.Statistics;
+
+        // Assert
+        stats.BugCount.Should().Be(3);
+    }
+
+    #endregion
+}
+
+public class IssueSummaryStatisticsTests
+{
+    #region HasIssues Tests
+
+    [Fact]
+    public void HasIssues_TotalCount為零_應回傳false()
+    {
+        // Arrange
+        var stats = new IssueSummaryStatistics { TotalCount = 0 };
+
+        // Act & Assert
+        stats.HasIssues.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasIssues_TotalCount大於零_應回傳true()
+    {
+        // Arrange
+        var stats = new IssueSummaryStatistics { TotalCount = 3 };
+
+        // Act & Assert
+        stats.HasIssues.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region GetSeverityCssClass Tests
+
+    [Theory]
+    [InlineData("bug", "badge-danger")]
+    [InlineData("error", "badge-danger")]
+    [InlineData("BUG", "badge-danger")]
+    [InlineData("ERROR", "badge-danger")]
+    public void GetSeverityCssClass_Bug或Error嚴重程度_應回傳badge_danger(string severity, string expected)
+    {
+        // Arrange
+        var stats = new IssueSummaryStatistics();
+
+        // Act
+        var result = stats.GetSeverityCssClass(severity);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("warning", "badge-warning")]
+    [InlineData("WARNING", "badge-warning")]
+    public void GetSeverityCssClass_Warning嚴重程度_應回傳badge_warning(string severity, string expected)
+    {
+        // Arrange
+        var stats = new IssueSummaryStatistics();
+
+        // Act
+        var result = stats.GetSeverityCssClass(severity);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("info", "badge-info")]
+    [InlineData("information", "badge-info")]
+    [InlineData("INFO", "badge-info")]
+    public void GetSeverityCssClass_Info或Information嚴重程度_應回傳badge_info(string severity, string expected)
+    {
+        // Arrange
+        var stats = new IssueSummaryStatistics();
+
+        // Act
+        var result = stats.GetSeverityCssClass(severity);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("suggestion", "badge-success")]
+    [InlineData("SUGGESTION", "badge-success")]
+    public void GetSeverityCssClass_Suggestion嚴重程度_應回傳badge_success(string severity, string expected)
+    {
+        // Arrange
+        var stats = new IssueSummaryStatistics();
+
+        // Act
+        var result = stats.GetSeverityCssClass(severity);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("unknown", "badge-secondary")]
+    [InlineData("other", "badge-secondary")]
+    [InlineData("", "badge-secondary")]
+    public void GetSeverityCssClass_未知嚴重程度_應回傳badge_secondary(string severity, string expected)
+    {
+        // Arrange
+        var stats = new IssueSummaryStatistics();
+
+        // Act
+        var result = stats.GetSeverityCssClass(severity);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetSeverityCssClass_傳入null_應回傳badge_secondary()
+    {
+        // Arrange
+        var stats = new IssueSummaryStatistics();
+
+        // Act
+        var result = stats.GetSeverityCssClass(null!);
+
+        // Assert
+        result.Should().Be("badge-secondary");
+    }
+
+    #endregion
+}
+
+public class ReviewIssueTests
+{
+    [Fact]
+    public void ReviewIssue_建立新實例_預設值應正確()
+    {
+        // Act
+        var issue = new ReviewIssue();
+
+        // Assert
+        issue.Severity.Should().BeEmpty();
+        issue.Message

--- a/tests/Generated/src/AiTeam.Shared/Models/ReviewReportTests.cs
+++ b/tests/Generated/src/AiTeam.Shared/Models/ReviewReportTests.cs
@@ -1,0 +1,386 @@
+```csharp
+using System;
+using System.Collections.Generic;
+using AiTeam.Shared.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace AiTeam.Shared.Tests.Models
+{
+    public class ReviewReportTests
+    {
+        [Fact]
+        public void ReviewReport_建立預設實例_所有屬性應有預設值()
+        {
+            // Arrange & Act
+            var report = new ReviewReport();
+
+            // Assert
+            report.Id.Should().BeEmpty();
+            report.Title.Should().BeEmpty();
+            report.Content.Should().BeEmpty();
+            report.Issues.Should().NotBeNull().And.BeEmpty();
+            report.Summary.Should().NotBeNull();
+            report.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        }
+
+        [Fact]
+        public void ReviewReport_設定所有屬性_應正確儲存值()
+        {
+            // Arrange
+            var expectedId = "report-001";
+            var expectedTitle = "Code Review Report";
+            var expectedContent = "This is the report content.";
+            var expectedCreatedAt = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+            var expectedIssues = new List<ReviewIssue>
+            {
+                new ReviewIssue { Id = "issue-001", Type = ReviewIssueType.Bug }
+            };
+            var expectedSummary = new ReviewIssueSummary { TotalCount = 1, BugCount = 1 };
+
+            // Act
+            var report = new ReviewReport
+            {
+                Id = expectedId,
+                Title = expectedTitle,
+                Content = expectedContent,
+                CreatedAt = expectedCreatedAt,
+                Issues = expectedIssues,
+                Summary = expectedSummary
+            };
+
+            // Assert
+            report.Id.Should().Be(expectedId);
+            report.Title.Should().Be(expectedTitle);
+            report.Content.Should().Be(expectedContent);
+            report.CreatedAt.Should().Be(expectedCreatedAt);
+            report.Issues.Should().BeEquivalentTo(expectedIssues);
+            report.Summary.Should().BeEquivalentTo(expectedSummary);
+        }
+
+        [Fact]
+        public void ReviewReport_Issues清單_可以新增問題()
+        {
+            // Arrange
+            var report = new ReviewReport();
+            var issue = new ReviewIssue
+            {
+                Id = "issue-001",
+                Type = ReviewIssueType.Warning,
+                Description = "Potential null reference"
+            };
+
+            // Act
+            report.Issues.Add(issue);
+
+            // Assert
+            report.Issues.Should().HaveCount(1);
+            report.Issues[0].Should().BeEquivalentTo(issue);
+        }
+
+        [Fact]
+        public void ReviewReport_設定空白Issues清單_應正常運作()
+        {
+            // Arrange & Act
+            var report = new ReviewReport
+            {
+                Issues = new List<ReviewIssue>()
+            };
+
+            // Assert
+            report.Issues.Should().NotBeNull().And.BeEmpty();
+        }
+    }
+
+    public class ReviewIssueTests
+    {
+        [Fact]
+        public void ReviewIssue_建立預設實例_所有屬性應有預設值()
+        {
+            // Arrange & Act
+            var issue = new ReviewIssue();
+
+            // Assert
+            issue.Id.Should().BeEmpty();
+            issue.Type.Should().Be(ReviewIssueType.Info);
+            issue.Description.Should().BeEmpty();
+            issue.FilePath.Should().BeEmpty();
+            issue.LineNumber.Should().BeNull();
+            issue.Suggestion.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ReviewIssue_設定所有屬性_應正確儲存值()
+        {
+            // Arrange
+            var expectedId = "issue-001";
+            var expectedType = ReviewIssueType.Bug;
+            var expectedDescription = "Null pointer dereference";
+            var expectedFilePath = "src/Service/MyService.cs";
+            var expectedLineNumber = 42;
+            var expectedSuggestion = "Add null check before accessing the property";
+
+            // Act
+            var issue = new ReviewIssue
+            {
+                Id = expectedId,
+                Type = expectedType,
+                Description = expectedDescription,
+                FilePath = expectedFilePath,
+                LineNumber = expectedLineNumber,
+                Suggestion = expectedSuggestion
+            };
+
+            // Assert
+            issue.Id.Should().Be(expectedId);
+            issue.Type.Should().Be(expectedType);
+            issue.Description.Should().Be(expectedDescription);
+            issue.FilePath.Should().Be(expectedFilePath);
+            issue.LineNumber.Should().Be(expectedLineNumber);
+            issue.Suggestion.Should().Be(expectedSuggestion);
+        }
+
+        [Fact]
+        public void ReviewIssue_LineNumber為Null_應可正常設定與讀取()
+        {
+            // Arrange & Act
+            var issue = new ReviewIssue
+            {
+                LineNumber = null
+            };
+
+            // Assert
+            issue.LineNumber.Should().BeNull();
+        }
+
+        [Fact]
+        public void ReviewIssue_LineNumber設定為零_應正確儲存()
+        {
+            // Arrange & Act
+            var issue = new ReviewIssue
+            {
+                LineNumber = 0
+            };
+
+            // Assert
+            issue.LineNumber.Should().Be(0);
+        }
+    }
+
+    public class ReviewIssueSummaryTests
+    {
+        [Fact]
+        public void ReviewIssueSummary_建立預設實例_所有計數應為零()
+        {
+            // Arrange & Act
+            var summary = new ReviewIssueSummary();
+
+            // Assert
+            summary.TotalCount.Should().Be(0);
+            summary.BugCount.Should().Be(0);
+            summary.WarningCount.Should().Be(0);
+            summary.InfoCount.Should().Be(0);
+            summary.SecurityCount.Should().Be(0);
+            summary.PerformanceCount.Should().Be(0);
+            summary.StyleCount.Should().Be(0);
+        }
+
+        [Fact]
+        public void FromIssues_傳入空清單_所有計數應為零()
+        {
+            // Arrange
+            var issues = new List<ReviewIssue>();
+
+            // Act
+            var summary = ReviewIssueSummary.FromIssues(issues);
+
+            // Assert
+            summary.TotalCount.Should().Be(0);
+            summary.BugCount.Should().Be(0);
+            summary.WarningCount.Should().Be(0);
+            summary.InfoCount.Should().Be(0);
+            summary.SecurityCount.Should().Be(0);
+            summary.PerformanceCount.Should().Be(0);
+            summary.StyleCount.Should().Be(0);
+        }
+
+        [Fact]
+        public void FromIssues_傳入混合類型問題清單_應正確統計各類型數量()
+        {
+            // Arrange
+            var issues = new List<ReviewIssue>
+            {
+                new ReviewIssue { Type = ReviewIssueType.Bug },
+                new ReviewIssue { Type = ReviewIssueType.Bug },
+                new ReviewIssue { Type = ReviewIssueType.Warning },
+                new ReviewIssue { Type = ReviewIssueType.Info },
+                new ReviewIssue { Type = ReviewIssueType.Security },
+                new ReviewIssue { Type = ReviewIssueType.Performance },
+                new ReviewIssue { Type = ReviewIssueType.Style },
+                new ReviewIssue { Type = ReviewIssueType.Style }
+            };
+
+            // Act
+            var summary = ReviewIssueSummary.FromIssues(issues);
+
+            // Assert
+            summary.TotalCount.Should().Be(8);
+            summary.BugCount.Should().Be(2);
+            summary.WarningCount.Should().Be(1);
+            summary.InfoCount.Should().Be(1);
+            summary.SecurityCount.Should().Be(1);
+            summary.PerformanceCount.Should().Be(1);
+            summary.StyleCount.Should().Be(2);
+        }
+
+        [Fact]
+        public void FromIssues_傳入單一Bug問題_BugCount應為一且TotalCount為一()
+        {
+            // Arrange
+            var issues = new List<ReviewIssue>
+            {
+                new ReviewIssue { Type = ReviewIssueType.Bug }
+            };
+
+            // Act
+            var summary = ReviewIssueSummary.FromIssues(issues);
+
+            // Assert
+            summary.TotalCount.Should().Be(1);
+            summary.BugCount.Should().Be(1);
+            summary.WarningCount.Should().Be(0);
+            summary.InfoCount.Should().Be(0);
+            summary.SecurityCount.Should().Be(0);
+            summary.PerformanceCount.Should().Be(0);
+            summary.StyleCount.Should().Be(0);
+        }
+
+        [Fact]
+        public void FromIssues_傳入所有相同類型問題_應只增加對應計數()
+        {
+            // Arrange
+            var issues = new List<ReviewIssue>
+            {
+                new ReviewIssue { Type = ReviewIssueType.Security },
+                new ReviewIssue { Type = ReviewIssueType.Security },
+                new ReviewIssue { Type = ReviewIssueType.Security }
+            };
+
+            // Act
+            var summary = ReviewIssueSummary.FromIssues(issues);
+
+            // Assert
+            summary.TotalCount.Should().Be(3);
+            summary.SecurityCount.Should().Be(3);
+            summary.BugCount.Should().Be(0);
+            summary.WarningCount.Should().Be(0);
+            summary.InfoCount.Should().Be(0);
+            summary.PerformanceCount.Should().Be(0);
+            summary.StyleCount.Should().Be(0);
+        }
+
+        [Fact]
+        public void ToDictionary_預設實例_應回傳包含七個鍵的字典且值均為零()
+        {
+            // Arrange
+            var summary = new ReviewIssueSummary();
+
+            // Act
+            var result = summary.ToDictionary();
+
+            // Assert
+            result.Should().HaveCount(7);
+            result.Should().ContainKey("Total").WhoseValue.Should().Be(0);
+            result.Should().ContainKey("Bug").WhoseValue.Should().Be(0);
+            result.Should().ContainKey("Warning").WhoseValue.Should().Be(0);
+            result.Should().ContainKey("Info").WhoseValue.Should().Be(0);
+            result.Should().ContainKey("Security").WhoseValue.Should().Be(0);
+            result.Should().ContainKey("Performance").WhoseValue.Should().Be(0);
+            result.Should().ContainKey("Style").WhoseValue.Should().Be(0);
+        }
+
+        [Fact]
+        public void ToDictionary_設定各計數後_應回傳對應正確值的字典()
+        {
+            // Arrange
+            var summary = new ReviewIssueSummary
+            {
+                TotalCount = 10,
+                BugCount = 3,
+                WarningCount = 2,
+                InfoCount = 1,
+                SecurityCount = 2,
+                PerformanceCount = 1,
+                StyleCount = 1
+            };
+
+            // Act
+            var result = summary.ToDictionary();
+
+            // Assert
+            result.Should().HaveCount(7);
+            result["Total"].Should().Be(10);
+            result["Bug"].Should().Be(3);
+            result["Warning"].Should().Be(2);
+            result["Info"].Should().Be(1);
+            result["Security"].Should().Be(2);
+            result["Performance"].Should().Be(1);
+            result["Style"].Should().Be(1);
+        }
+
+        [Fact]
+        public void ToDictionary_從FromIssues建立後_字典值應與統計計數一致()
+        {
+            // Arrange
+            var issues = new List<ReviewIssue>
+            {
+                new ReviewIssue { Type = ReviewIssueType.Bug },
+                new ReviewIssue { Type = ReviewIssueType.Warning },
+                new ReviewIssue { Type = ReviewIssueType.Info },
+                new ReviewIssue { Type = ReviewIssueType.Security },
+                new ReviewIssue { Type = ReviewIssueType.Performance },
+                new ReviewIssue { Type = ReviewIssueType.Style }
+            };
+
+            // Act
+            var summary = ReviewIssueSummary.FromIssues(issues);
+            var result = summary.ToDictionary();
+
+            // Assert
+            result["Total"].Should().Be(summary.TotalCount);
+            result["Bug"].Should().Be(summary.BugCount);
+            result["Warning"].Should().Be(summary.WarningCount);
+            result["Info"].Should().Be(summary.InfoCount);
+            result["Security"].Should().Be(summary.SecurityCount);
+            result["Performance"].Should().Be(summary.PerformanceCount);
+            result["Style"].Should().Be(summary.StyleCount);
+        }
+    }
+
+    public class ReviewIssueTypeTests
+    {
+        [Theory]
+        [InlineData(ReviewIssueType.Bug, 0)]
+        [InlineData(ReviewIssueType.Warning, 1)]
+        [InlineData(ReviewIssueType.Info, 2)]
+        [InlineData(ReviewIssueType.Security, 3)]
+        [InlineData(ReviewIssueType.Performance, 4)]
+        [InlineData(ReviewIssueType.Style, 5)]
+        public void ReviewIssueType_列舉值_應具備正確的整數對應值(ReviewIssueType type, int expectedValue)
+        {
+            // Assert
+            ((int)type).Should().Be(expectedValue);
+        }
+
+        [Fact]
+        public void ReviewIssueType_列舉_應包含六個成員()
+        {
+            // Arrange & Act
+            var values = Enum.GetValues(typeof(ReviewIssueType));
+
+            // Assert
+            values.Length.Should().Be(6);
+        }
+    }
+}
+```


### PR DESCRIPTION
## QA Agent 自動測試

針對 PR #35 的變更，自動產生以下測試：
- `tests/Generated/src/AiTeam.Bot/Agents/ReviewerAgentTests.cs`
- `tests/Generated/src/AiTeam.Dashboard/Components/Pages/ReviewerAgent.razorTests.cs`
- `tests/Generated/src/AiTeam.Shared/Models/ReviewReportTests.cs`
- `src/AiTeam.Tests.Playwright/Generated/PR35/VisualTests.cs`

## 測試框架
- xUnit + NSubstitute + FluentAssertions（邏輯測試）
- Playwright（UI 視覺截圖測試，PR 合併前 CI 自動執行並附上截圖）

---
🤖 由 AiTeam QA Agent 自動產出