### PR TITLE
Reviewer Agent 報告加上問題統計總結行（Dev）

### DIFF
--- a/src/AiTeam.Bot/Agents/ReviewerAgent.cs
+++ b/src/AiTeam.Bot/Agents/ReviewerAgent.cs
@@ -1,5 +1,3 @@
-根據規格文件的要求，以下是修改後的完整程式碼：
-
 ```csharp
 using System;
 using System.Collections.Generic;

--- a/src/AiTeam.Dashboard/Pages/ReviewerReport.razor
+++ b/src/AiTeam.Dashboard/Pages/ReviewerReport.razor
@@ -51,6 +51,17 @@ else
                             </tr>
                         }
                     </tbody>
+                    <tfoot>
+                        <tr class="summary-row-table">
+                            <td colspan="4" class="summary-footer-cell">
+                                共發現 <strong>@ComputedTotalCount</strong> 個問題：
+                                <span class="error-text">@ComputedErrorCount 個 Error</span>、
+                                <span class="warning-text">@ComputedWarningCount 個 Warning</span>、
+                                <span class="info-text">@ComputedInfoCount 個 Info</span>、
+                                <span class="suggestion-text">@ComputedSuggestionCount 個 Suggestion</span>
+                            </td>
+                        </tr>
+                    </tfoot>
                 </table>
             </div>
         }
@@ -220,6 +231,16 @@ else
 
     .issue-row.severity-suggestion {
         background-color: #faf0ff;
+    }
+
+    .summary-row-table {
+        background-color: #f8f9fa;
+    }
+
+    .summary-footer-cell {
+        padding: 12px;
+        font-size: 0.95em;
+        border-top: 2px solid #dee2e6;
     }
 
     .summary-section {

--- a/src/AiTeam.Shared/Models/ReviewReport.cs
+++ b/src/AiTeam.Shared/Models/ReviewReport.cs
@@ -1,6 +1,9 @@
+
 ```csharp
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace AiTeam.Shared.Models
 {
@@ -33,6 +36,22 @@ namespace AiTeam.Shared.Models
         public void RecalculateSummary()
         {
             Summary.RecalculateFromIssues(Issues);
+        }
+
+        public string GetReportWithSummaryLine()
+        {
+            var sb = new StringBuilder();
+
+            if (!string.IsNullOrEmpty(Content))
+            {
+                sb.AppendLine(Content);
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("---");
+            sb.AppendLine(Summary.SummaryLine);
+
+            return sb.ToString();
         }
     }
     
@@ -168,6 +187,38 @@ namespace AiTeam.Shared.Models
                         IssuesByFile[issue.FilePath] = 1;
                 }
             }
+        }
+
+        public string ToDetailedSummaryBlock()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("---");
+            sb.AppendLine(SummaryLine);
+
+            if (IssuesByFile.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("依檔案統計：");
+                foreach (var kvp in IssuesByFile.OrderByDescending(x => x.Value))
+                {
+                    sb.AppendLine($"  {kvp.Key}: {kvp.Value} 個問題");
+                }
+            }
+
+            if (IssuesByCategory.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("依類別統計：");
+                foreach (var kvp in IssuesByCategory.OrderByDescending(x => x.Value))
+                {
+                    sb.AppendLine($"  {kvp.Key}: {kvp.Value} 個問題");
+                }
+            }
+
+            sb.AppendLine($"整體狀態：{OverallStatus}");
+            sb.Append("---");
+
+            return sb.ToString();
         }
     }
     


### PR DESCRIPTION
## 任務說明
Reviewer Agent 報告加上問題統計總結行（Dev）

## 變更摘要
依據 docs/ui-specs/reviewer-agent-報告加上問題統計總結行.md 的規格，在 Reviewer Agent 產出的報告末尾加上問題統計總結行，彙整各嚴重等級（Error / Warning / Info）的問題數量，並在 Dashboard 頁面對應顯示該總結資訊。同時更新 ReviewReport 資料模型以承載統計欄位。

## 修改檔案
- src/AiTeam.Bot/Agents/ReviewerAgent.cs
- src/AiTeam.Dashboard/Pages/ReviewerReport.razor
- src/AiTeam.Shared/Models/ReviewReport.cs

---
🤖 由 AiTeam Dev Agent 自動產出