### PR TITLE
test: QA 自動測試（PR #51）

### DIFF
--- a/src/AiTeam.Tests.Playwright/Generated/PR51/VisualTests.cs
+++ b/src/AiTeam.Tests.Playwright/Generated/PR51/VisualTests.cs
@@ -1,0 +1,168 @@
+using Microsoft.Playwright.MSTest;
+using Microsoft.Playwright;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace AiTeam.Tests.Playwright.Generated
+{
+    [TestClass]
+    public class ReviewerReportPageTests : PageTest
+    {
+        private string _dashboardUrl = string.Empty;
+        private string _dashboardUser = string.Empty;
+        private string _dashboardPass = string.Empty;
+        private string _screenshotDir = string.Empty;
+
+        [TestInitialize]
+        public async Task 測試初始化()
+        {
+            _dashboardUrl = Environment.GetEnvironmentVariable("DASHBOARD_URL") ?? "http://localhost:5051";
+            _dashboardUser = Environment.GetEnvironmentVariable("DASHBOARD_USER") ?? string.Empty;
+            _dashboardPass = Environment.GetEnvironmentVariable("DASHBOARD_PASS") ?? string.Empty;
+            _screenshotDir = Path.Combine(Directory.GetCurrentDirectory(), "screenshots");
+            Directory.CreateDirectory(_screenshotDir);
+
+            await 執行登入();
+        }
+
+        private async Task 執行登入()
+        {
+            if (string.IsNullOrEmpty(_dashboardUser) || string.IsNullOrEmpty(_dashboardPass))
+                return;
+
+            await Page.GotoAsync($"{_dashboardUrl}/login");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+            var usernameInput = Page.Locator("input[type='text'], input[name='username'], input[id='username'], input[placeholder*='用戶'], input[placeholder*='帳號'], input[placeholder*='Email'], input[type='email']");
+            if (await usernameInput.First.IsVisibleAsync())
+                await usernameInput.First.FillAsync(_dashboardUser);
+
+            var passwordInput = Page.Locator("input[type='password']");
+            if (await passwordInput.First.IsVisibleAsync())
+                await passwordInput.First.FillAsync(_dashboardPass);
+
+            var submitButton = Page.Locator("button[type='submit'], button:has-text('登入'), button:has-text('Login'), button:has-text('Sign in')");
+            if (await submitButton.First.IsVisibleAsync())
+            {
+                await submitButton.First.ClickAsync();
+                await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            }
+        }
+
+        private async Task 切換深色模式()
+        {
+            var darkModeToggle = Page.Locator(
+                "button[aria-label*='dark'], button[aria-label*='Dark'], " +
+                "button[aria-label*='夜間'], button[aria-label*='深色'], " +
+                "input[type='checkbox'][id*='dark'], input[type='checkbox'][id*='theme'], " +
+                ".dark-mode-toggle, .theme-toggle, " +
+                "[data-testid='dark-mode-toggle'], [data-testid='theme-toggle'], " +
+                "button:has-text('Dark'), button:has-text('夜間模式'), button:has-text('深色模式')"
+            );
+
+            if (await darkModeToggle.First.IsVisibleAsync())
+            {
+                await darkModeToggle.First.ClickAsync();
+                await Page.WaitForTimeoutAsync(800);
+            }
+        }
+
+        private async Task 儲存截圖(string fileName)
+        {
+            var filePath = Path.Combine(_screenshotDir, fileName);
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path = filePath,
+                FullPage = true
+            });
+        }
+
+        [TestMethod]
+        public async Task 審閱者報表頁面_亮色模式_截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/reviewer-report");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1000);
+
+            await 儲存截圖("PR51_ReviewerReport_亮色模式.png");
+
+            Assert.IsTrue(File.Exists(Path.Combine(_screenshotDir, "PR51_ReviewerReport_亮色模式.png")),
+                "審閱者報表頁面亮色模式截圖應成功儲存");
+        }
+
+        [TestMethod]
+        public async Task 審閱者報表頁面_深色模式_截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/reviewer-report");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1000);
+
+            await 切換深色模式();
+
+            await 儲存截圖("PR51_ReviewerReport_深色模式.png");
+
+            Assert.IsTrue(File.Exists(Path.Combine(_screenshotDir, "PR51_ReviewerReport_深色模式.png")),
+                "審閱者報表頁面深色模式截圖應成功儲存");
+        }
+
+        [TestMethod]
+        public async Task 審閱者報表頁面_驗證頁面基本元素存在()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/reviewer-report");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1000);
+
+            var pageContent = await Page.ContentAsync();
+            Assert.IsTrue(pageContent.Length > 0, "頁面內容不應為空");
+
+            await 儲存截圖("PR51_ReviewerReport_基本元素驗證.png");
+        }
+
+        [TestMethod]
+        public async Task 審閱者報表頁面_驗證無主控台錯誤()
+        {
+            var consoleErrors = new System.Collections.Generic.List<string>();
+
+            Page.Console += (_, msg) =>
+            {
+                if (msg.Type == "error")
+                    consoleErrors.Add(msg.Text);
+            };
+
+            await Page.GotoAsync($"{_dashboardUrl}/reviewer-report");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 儲存截圖("PR51_ReviewerReport_主控台錯誤檢查.png");
+
+            if (consoleErrors.Count > 0)
+            {
+                Console.WriteLine($"偵測到主控台錯誤：{string.Join(", ", consoleErrors)}");
+            }
+
+            Assert.IsTrue(File.Exists(Path.Combine(_screenshotDir, "PR51_ReviewerReport_主控台錯誤檢查.png")),
+                "審閱者報表頁面截圖應成功儲存");
+        }
+
+        [TestMethod]
+        public async Task 審閱者報表頁面_亮色與深色模式切換_截圖對比驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/reviewer-report");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1000);
+
+            await 儲存截圖("PR51_ReviewerReport_切換前亮色.png");
+
+            await 切換深色模式();
+
+            await 儲存截圖("PR51_ReviewerReport_切換後深色.png");
+
+            Assert.IsTrue(File.Exists(Path.Combine(_screenshotDir, "PR51_ReviewerReport_切換前亮色.png")),
+                "切換前亮色模式截圖應存在");
+            Assert.IsTrue(File.Exists(Path.Combine(_screenshotDir, "PR51_ReviewerReport_切換後深色.png")),
+                "切換後深色模式截圖應存在");
+        }
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Pages/ReviewerReport.razorTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Pages/ReviewerReport.razorTests.cs
@@ -1,0 +1,405 @@
+```csharp
+using AiTeam.Dashboard.Models;
+using AiTeam.Dashboard.Pages;
+using AiTeam.Dashboard.Services;
+using FluentAssertions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using System.Reflection;
+using Xunit;
+
+namespace AiTeam.Dashboard.Tests.Pages;
+
+public class ReviewerReportTests
+{
+    private readonly IReviewerReportService _reviewerReportService;
+    private readonly ReviewerReport _sut;
+
+    public ReviewerReportTests()
+    {
+        _reviewerReportService = Substitute.For<IReviewerReportService>();
+        _sut = new ReviewerReport();
+
+        // 注入 mock service
+        var serviceProperty = typeof(ReviewerReport)
+            .GetProperty("ReviewerReportService", BindingFlags.NonPublic | BindingFlags.Instance);
+        serviceProperty!.SetValue(_sut, _reviewerReportService);
+    }
+
+    #region Helper Methods
+
+    private List<ReviewerReportItem> GetReportItems() =>
+        GetPrivateProperty<List<ReviewerReportItem>>("ReportItems")!;
+
+    private ReviewerReportSummary GetSummary() =>
+        GetPrivateProperty<ReviewerReportSummary>("Summary")!;
+
+    private bool GetIsLoading() =>
+        GetPrivateProperty<bool>("IsLoading");
+
+    private string? GetErrorMessage() =>
+        GetPrivateProperty<string?>("ErrorMessage");
+
+    private T? GetPrivateProperty<T>(string propertyName)
+    {
+        var property = typeof(ReviewerReport)
+            .GetProperty(propertyName, BindingFlags.NonPublic | BindingFlags.Instance);
+        return (T?)property!.GetValue(_sut);
+    }
+
+    private async Task InvokeLoadReportDataAsync()
+    {
+        var method = typeof(ReviewerReport)
+            .GetMethod("LoadReportDataAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+        await (Task)method!.Invoke(_sut, null)!;
+    }
+
+    private async Task InvokeOnInitializedAsync()
+    {
+        var method = typeof(ReviewerReport)
+            .GetMethod("OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+        await (Task)method!.Invoke(_sut, null)!;
+    }
+
+    private async Task InvokeRefreshAsync()
+    {
+        var method = typeof(ReviewerReport)
+            .GetMethod("RefreshAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+        await (Task)method!.Invoke(_sut, null)!;
+    }
+
+    private static ReviewerReportSummary InvokeCalculateSummary(List<ReviewerReportItem> items)
+    {
+        var method = typeof(ReviewerReport)
+            .GetMethod("CalculateSummary", BindingFlags.NonPublic | BindingFlags.Static);
+        return (ReviewerReportSummary)method!.Invoke(null, new object[] { items })!;
+    }
+
+    #endregion
+
+    #region OnInitializedAsync Tests
+
+    [Fact]
+    public async Task 初始化_服務回傳報告資料_應正確載入報告項目()
+    {
+        // Arrange
+        var expectedItems = new List<ReviewerReportItem>
+        {
+            new() { IssueType = IssueType.Error },
+            new() { IssueType = IssueType.Warning },
+            new() { IssueType = IssueType.Suggestion }
+        };
+        _reviewerReportService.GetReportItemsAsync().Returns(expectedItems);
+
+        // Act
+        await InvokeOnInitializedAsync();
+
+        // Assert
+        var reportItems = GetReportItems();
+        reportItems.Should().BeEquivalentTo(expectedItems);
+        GetIsLoading().Should().BeFalse();
+        GetErrorMessage().Should().BeNull();
+    }
+
+    [Fact]
+    public async Task 初始化_服務拋出例外_應設定錯誤訊息()
+    {
+        // Arrange
+        var exceptionMessage = "連線逾時";
+        _reviewerReportService.GetReportItemsAsync()
+            .ThrowsAsync(new Exception(exceptionMessage));
+
+        // Act
+        await InvokeOnInitializedAsync();
+
+        // Assert
+        GetErrorMessage().Should().Contain(exceptionMessage);
+        GetErrorMessage().Should().Contain("載入報告資料時發生錯誤");
+        GetIsLoading().Should().BeFalse();
+    }
+
+    #endregion
+
+    #region LoadReportDataAsync Tests
+
+    [Fact]
+    public async Task 載入報告資料_成功取得資料_IsLoading應為False且ErrorMessage應為Null()
+    {
+        // Arrange
+        var items = new List<ReviewerReportItem>
+        {
+            new() { IssueType = IssueType.Error },
+            new() { IssueType = IssueType.Info }
+        };
+        _reviewerReportService.GetReportItemsAsync().Returns(items);
+
+        // Act
+        await InvokeLoadReportDataAsync();
+
+        // Assert
+        GetIsLoading().Should().BeFalse();
+        GetErrorMessage().Should().BeNull();
+        GetReportItems().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task 載入報告資料_服務拋出例外_IsLoading應為False且應有錯誤訊息()
+    {
+        // Arrange
+        _reviewerReportService.GetReportItemsAsync()
+            .ThrowsAsync(new InvalidOperationException("無效操作"));
+
+        // Act
+        await InvokeLoadReportDataAsync();
+
+        // Assert
+        GetIsLoading().Should().BeFalse();
+        GetErrorMessage().Should().NotBeNullOrEmpty();
+        GetErrorMessage().Should().Contain("無效操作");
+    }
+
+    [Fact]
+    public async Task 載入報告資料_成功取得資料_應計算正確摘要()
+    {
+        // Arrange
+        var items = new List<ReviewerReportItem>
+        {
+            new() { IssueType = IssueType.Error },
+            new() { IssueType = IssueType.Error },
+            new() { IssueType = IssueType.Warning },
+            new() { IssueType = IssueType.Suggestion },
+            new() { IssueType = IssueType.Info }
+        };
+        _reviewerReportService.GetReportItemsAsync().Returns(items);
+
+        // Act
+        await InvokeLoadReportDataAsync();
+
+        // Assert
+        var summary = GetSummary();
+        summary.TotalCount.Should().Be(5);
+        summary.ErrorCount.Should().Be(2);
+        summary.WarningCount.Should().Be(1);
+        summary.SuggestionCount.Should().Be(1);
+        summary.InfoCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task 載入報告資料_服務回傳空清單_摘要應全為零()
+    {
+        // Arrange
+        _reviewerReportService.GetReportItemsAsync().Returns(new List<ReviewerReportItem>());
+
+        // Act
+        await InvokeLoadReportDataAsync();
+
+        // Assert
+        var summary = GetSummary();
+        summary.TotalCount.Should().Be(0);
+        summary.ErrorCount.Should().Be(0);
+        summary.WarningCount.Should().Be(0);
+        summary.SuggestionCount.Should().Be(0);
+        summary.InfoCount.Should().Be(0);
+    }
+
+    #endregion
+
+    #region CalculateSummary Tests
+
+    [Fact]
+    public void 計算摘要_包含各類型問題_應正確統計各類型數量()
+    {
+        // Arrange
+        var items = new List<ReviewerReportItem>
+        {
+            new() { IssueType = IssueType.Error },
+            new() { IssueType = IssueType.Error },
+            new() { IssueType = IssueType.Error },
+            new() { IssueType = IssueType.Warning },
+            new() { IssueType = IssueType.Warning },
+            new() { IssueType = IssueType.Suggestion },
+            new() { IssueType = IssueType.Info }
+        };
+
+        // Act
+        var summary = InvokeCalculateSummary(items);
+
+        // Assert
+        summary.TotalCount.Should().Be(7);
+        summary.ErrorCount.Should().Be(3);
+        summary.WarningCount.Should().Be(2);
+        summary.SuggestionCount.Should().Be(1);
+        summary.InfoCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void 計算摘要_空清單_應回傳全零摘要()
+    {
+        // Arrange
+        var items = new List<ReviewerReportItem>();
+
+        // Act
+        var summary = InvokeCalculateSummary(items);
+
+        // Assert
+        summary.TotalCount.Should().Be(0);
+        summary.ErrorCount.Should().Be(0);
+        summary.WarningCount.Should().Be(0);
+        summary.SuggestionCount.Should().Be(0);
+        summary.InfoCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void 計算摘要_只有錯誤類型_其他類型數量應為零()
+    {
+        // Arrange
+        var items = new List<ReviewerReportItem>
+        {
+            new() { IssueType = IssueType.Error },
+            new() { IssueType = IssueType.Error }
+        };
+
+        // Act
+        var summary = InvokeCalculateSummary(items);
+
+        // Assert
+        summary.TotalCount.Should().Be(2);
+        summary.ErrorCount.Should().Be(2);
+        summary.WarningCount.Should().Be(0);
+        summary.SuggestionCount.Should().Be(0);
+        summary.InfoCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void 計算摘要_只有提示類型_TotalCount應等於InfoCount()
+    {
+        // Arrange
+        var items = new List<ReviewerReportItem>
+        {
+            new() { IssueType = IssueType.Info },
+            new() { IssueType = IssueType.Info },
+            new() { IssueType = IssueType.Info }
+        };
+
+        // Act
+        var summary = InvokeCalculateSummary(items);
+
+        // Assert
+        summary.TotalCount.Should().Be(3);
+        summary.InfoCount.Should().Be(3);
+        summary.ErrorCount.Should().Be(0);
+        summary.WarningCount.Should().Be(0);
+        summary.SuggestionCount.Should().Be(0);
+    }
+
+    #endregion
+
+    #region RefreshAsync Tests
+
+    [Fact]
+    public async Task 重新整理_呼叫成功_應重新載入報告資料()
+    {
+        // Arrange
+        var initialItems = new List<ReviewerReportItem>
+        {
+            new() { IssueType = IssueType.Error }
+        };
+        var refreshedItems = new List<ReviewerReportItem>
+        {
+            new() { IssueType = IssueType.Warning },
+            new() { IssueType = IssueType.Info }
+        };
+
+        _reviewerReportService.GetReportItemsAsync()
+            .Returns(initialItems, refreshedItems);
+
+        await InvokeLoadReportDataAsync();
+
+        // Act
+        await InvokeRefreshAsync();
+
+        // Assert
+        GetReportItems().Should().HaveCount(2);
+        GetReportItems().Should().Contain(i => i.IssueType == IssueType.Warning);
+        GetReportItems().Should().Contain(i => i.IssueType == IssueType.Info);
+        GetIsLoading().Should().BeFalse();
+        GetErrorMessage().Should().BeNull();
+    }
+
+    [Fact]
+    public async Task 重新整理_服務拋出例外_應設定錯誤訊息且IsLoading為False()
+    {
+        // Arrange
+        _reviewerReportService.GetReportItemsAsync()
+            .ThrowsAsync(new HttpRequestException("網路連線失敗"));
+
+        // Act
+        await InvokeRefreshAsync();
+
+        // Assert
+        GetIsLoading().Should().BeFalse();
+        GetErrorMessage().Should().NotBeNullOrEmpty();
+        GetErrorMessage().Should().Contain("網路連線失敗");
+    }
+
+    [Fact]
+    public async Task 重新整理_呼叫多次_應多次呼叫服務()
+    {
+        // Arrange
+        _reviewerReportService.GetReportItemsAsync()
+            .Returns(new List<ReviewerReportItem>());
+
+        // Act
+        await InvokeRefreshAsync();
+        await InvokeRefreshAsync();
+        await InvokeRefreshAsync();
+
+        // Assert
+        await _reviewerReportService.Received(3).GetReportItemsAsync();
+    }
+
+    #endregion
+
+    #region Error Handling Tests
+
+    [Fact]
+    public async Task 載入報告資料_發生例外後再次載入成功_ErrorMessage應被清除()
+    {
+        // Arrange
+        _reviewerReportService.GetReportItemsAsync()
+            .ThrowsAsync(new Exception("第一次失敗"));
+
+        await InvokeLoadReportDataAsync();
+        GetErrorMessage().Should().NotBeNull();
+
+        // 第二次成功
+        _reviewerReportService.GetReportItemsAsync()
+            .Returns(new List<ReviewerReportItem> { new() { IssueType = IssueType.Info } });
+
+        // Act
+        await InvokeLoadReportDataAsync();
+
+        // Assert
+        GetErrorMessage().Should().BeNull();
+        GetIsLoading().Should().BeFalse();
+        GetReportItems().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task 載入報告資料_例外訊息包含特殊字元_應完整保留錯誤訊息()
+    {
+        // Arrange
+        var specialMessage = "Error: <特殊字元> & \"引號\" 'apostrophe'";
+        _reviewerReportService.GetReportItemsAsync()
+            .ThrowsAsync(new Exception(specialMessage));
+
+        // Act
+        await InvokeLoadReportDataAsync();
+
+        // Assert
+        GetErrorMessage().Should().Contain(specialMessage);
+    }
+
+    #endregion
+}
+```

--- a/tests/Generated/src/AiTeam.Shared/Models/ReviewerReportSummaryTests.cs
+++ b/tests/Generated/src/AiTeam.Shared/Models/ReviewerReportSummaryTests.cs
@@ -1,0 +1,190 @@
+using FluentAssertions;
+using AiTeam.Shared.Models;
+
+namespace AiTeam.Shared.Tests.Models;
+
+public class ReviewerReportSummaryTests
+{
+    [Fact]
+    public void TotalCount_當三個計數皆為零_應回傳零()
+    {
+        // Arrange
+        var summary = new ReviewerReportSummary
+        {
+            ErrorCount = 0,
+            WarningCount = 0,
+            SuggestionCount = 0
+        };
+
+        // Act
+        var result = summary.TotalCount;
+
+        // Assert
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public void TotalCount_當三個計數皆有正整數_應回傳正確總和()
+    {
+        // Arrange
+        var summary = new ReviewerReportSummary
+        {
+            ErrorCount = 3,
+            WarningCount = 5,
+            SuggestionCount = 2
+        };
+
+        // Act
+        var result = summary.TotalCount;
+
+        // Assert
+        result.Should().Be(10);
+    }
+
+    [Fact]
+    public void TotalCount_當只有ErrorCount有值_應回傳ErrorCount的值()
+    {
+        // Arrange
+        var summary = new ReviewerReportSummary
+        {
+            ErrorCount = 7,
+            WarningCount = 0,
+            SuggestionCount = 0
+        };
+
+        // Act
+        var result = summary.TotalCount;
+
+        // Assert
+        result.Should().Be(7);
+    }
+
+    [Fact]
+    public void TotalCount_當只有WarningCount有值_應回傳WarningCount的值()
+    {
+        // Arrange
+        var summary = new ReviewerReportSummary
+        {
+            ErrorCount = 0,
+            WarningCount = 4,
+            SuggestionCount = 0
+        };
+
+        // Act
+        var result = summary.TotalCount;
+
+        // Assert
+        result.Should().Be(4);
+    }
+
+    [Fact]
+    public void TotalCount_當只有SuggestionCount有值_應回傳SuggestionCount的值()
+    {
+        // Arrange
+        var summary = new ReviewerReportSummary
+        {
+            ErrorCount = 0,
+            WarningCount = 0,
+            SuggestionCount = 9
+        };
+
+        // Act
+        var result = summary.TotalCount;
+
+        // Assert
+        result.Should().Be(9);
+    }
+
+    [Fact]
+    public void TotalCount_當動態變更ErrorCount後_應即時反映最新總和()
+    {
+        // Arrange
+        var summary = new ReviewerReportSummary
+        {
+            ErrorCount = 1,
+            WarningCount = 1,
+            SuggestionCount = 1
+        };
+
+        // Act
+        summary.ErrorCount = 10;
+        var result = summary.TotalCount;
+
+        // Assert
+        result.Should().Be(12);
+    }
+
+    [Fact]
+    public void ErrorCount_設定後_應可正確讀取()
+    {
+        // Arrange
+        var summary = new ReviewerReportSummary();
+
+        // Act
+        summary.ErrorCount = 5;
+
+        // Assert
+        summary.ErrorCount.Should().Be(5);
+    }
+
+    [Fact]
+    public void WarningCount_設定後_應可正確讀取()
+    {
+        // Arrange
+        var summary = new ReviewerReportSummary();
+
+        // Act
+        summary.WarningCount = 8;
+
+        // Assert
+        summary.WarningCount.Should().Be(8);
+    }
+
+    [Fact]
+    public void SuggestionCount_設定後_應可正確讀取()
+    {
+        // Arrange
+        var summary = new ReviewerReportSummary();
+
+        // Act
+        summary.SuggestionCount = 3;
+
+        // Assert
+        summary.SuggestionCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void 建構式_預設值_三個計數應皆為零()
+    {
+        // Arrange & Act
+        var summary = new ReviewerReportSummary();
+
+        // Assert
+        summary.ErrorCount.Should().Be(0);
+        summary.WarningCount.Should().Be(0);
+        summary.SuggestionCount.Should().Be(0);
+        summary.TotalCount.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(1, 2, 3, 6)]
+    [InlineData(0, 0, 1, 1)]
+    [InlineData(100, 200, 300, 600)]
+    [InlineData(int.MaxValue / 3, int.MaxValue / 3, int.MaxValue / 3, (int.MaxValue / 3) * 3)]
+    public void TotalCount_多組資料組合_應回傳正確總和(int errors, int warnings, int suggestions, int expected)
+    {
+        // Arrange
+        var summary = new ReviewerReportSummary
+        {
+            ErrorCount = errors,
+            WarningCount = warnings,
+            SuggestionCount = suggestions
+        };
+
+        // Act
+        var result = summary.TotalCount;
+
+        // Assert
+        result.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## QA Agent 自動測試

針對 PR #51 的變更，自動產生以下測試：
- `tests/Generated/src/AiTeam.Dashboard/Pages/ReviewerReport.razorTests.cs`
- `tests/Generated/src/AiTeam.Shared/Models/ReviewerReportSummaryTests.cs`
- `src/AiTeam.Tests.Playwright/Generated/PR51/VisualTests.cs`

## 測試框架
- xUnit + NSubstitute + FluentAssertions（邏輯測試）
- Playwright（UI 視覺截圖測試，PR 合併前 CI 自動執行並附上截圖）

---
🤖 由 AiTeam QA Agent 自動產出