### PR TITLE
在AiTeam專案中，Dashboard中任務中心頁面，移除重新整理這個按鈕

### DIFF
--- a/src/AiTeam.Dashboard/Components/Pages/Tasks/TaskCenter.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Tasks/TaskCenter.razor
@@ -14,7 +14,6 @@
             <option value="done">完成</option>
             <option value="failed">失敗</option>
         </select>
-        <button class="btn btn-secondary" @onclick="async () => await _tableRef.ReloadServerData()">重新整理</button>
     </div>
 </div>
 


### PR DESCRIPTION
## 任務說明
在AiTeam專案中，Dashboard中任務中心頁面，移除重新整理這個按鈕

## 變更摘要
在 Dashboard 的任務中心頁面（TaskCenter.razor）中，找到並移除「重新整理」按鈕的 HTML 元素及其對應的事件處理邏輯（如有）。僅移除 UI 元件，不影響其他功能。

---
🤖 由 AiTeam Dev Agent（Claude Code）自動產出