### PR TITLE
fix(dashboard): 隱藏 Kickoff/Design TaskItem 的重試按鈕

### DIFF
--- a/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineView.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineView.razor
@@ -173,7 +173,7 @@ else
                                        OnClick="@(() => LoadLogsAsync(step))">載入 Log</MudButton>
                         }
                         @* Stage 31：失敗 / 取消任務重試按鈕 *@
-                        @if (step.Task.Status is "failed" or "cancelled")
+                        @if (step.Task.Status is "failed" or "cancelled" && step.Task.AssignedAgent is not ("Kickoff" or "Design"))
                         {
                             <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Warning"
                                        StartIcon="@Icons.Material.Filled.Refresh"

--- a/src/AiTeam.Dashboard/Components/Pages/Tasks/TaskCenter.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Tasks/TaskCenter.razor
@@ -59,7 +59,7 @@
         <MudTd>@context.CompletedAt?.ToString("yyyy/MM/dd HH:mm")</MudTd>
         <MudTd>@FormatDuration(context.Duration)</MudTd>
         <MudTd @onclick:stopPropagation>
-            @if (context.Status is "failed" or "cancelled")
+            @if (context.Status is "failed" or "cancelled" && context.AssignedAgent is not ("Kickoff" or "Design"))
             {
                 <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Warning"
                            StartIcon="@Icons.Material.Filled.Refresh"


### PR DESCRIPTION
## Summary

- `PipelineView.razor` 與 `TaskCenter.razor` 的重試按鈕條件加上 `AssignedAgent is not ("Kickoff" or "Design")` 過濾
- Kickoff / Design 任務走 `RunKickoffMeetingAndWaitAsync` / `RunDesignPhaseAsync` 獨立路徑，`WorkflowAgentKey` 為 null
- 若對這兩種任務按重試，`AgentQueueProcessor` 撿到後找不到 executor，任務會立即再次失敗而非真正重跑會議

## Test plan

- [ ] 確認 failed/cancelled 的一般任務（Dev/Review/QA 等）仍顯示重試按鈕
- [ ] 確認 failed/cancelled 的 Kickoff / Design TaskItem 不再顯示重試按鈕

🤖 Generated with [Claude Code](https://claude.com/claude-code)