### PR TITLE
規則管理頁面表格 UI 微調：移除狀態文字 + 操作改圖示按鈕（Dev）

### DIFF
--- a/src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagement.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagement.razor
@@ -59,15 +59,21 @@ else if (_rules.Count > 0)
                 <MudSwitch T="bool"
                            Value="@context.IsActive"
                            ValueChanged="@((bool v) => ToggleActiveAsync(context, v))"
-                           Color="Color.Primary"
-                           Label="@(context.IsActive ? "啟用" : "停用")" />
+                           Color="Color.Primary" />
             </MudTd>
             <MudTd>
-                <MudStack Row="true" Spacing="2">
-                    <MudButton Size="Size.Small" Variant="Variant.Outlined"
-                               OnClick="@(() => OpenEditRuleDialogAsync(context))">編輯</MudButton>
-                    <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Error"
-                               OnClick="@(() => DeleteRuleAsync(context.Id))">刪除</MudButton>
+                <MudStack Row="true" Spacing="1">
+                    <MudTooltip Text="編輯">
+                        <MudIconButton Icon="@Icons.Material.Outlined.Edit"
+                                       Size="Size.Small"
+                                       OnClick="@(() => OpenEditRuleDialogAsync(context))" />
+                    </MudTooltip>
+                    <MudTooltip Text="刪除">
+                        <MudIconButton Icon="@Icons.Material.Outlined.Delete"
+                                       Size="Size.Small"
+                                       Color="Color.Error"
+                                       OnClick="@(() => DeleteRuleAsync(context.Id))" />
+                    </MudTooltip>
                 </MudStack>
             </MudTd>
         </RowTemplate>

--- a/src/AiTeam.Tests.Playwright/Generated/PR108/VisualTests.cs
+++ b/src/AiTeam.Tests.Playwright/Generated/PR108/VisualTests.cs
@@ -1,0 +1,415 @@
+using Microsoft.Playwright;
+using Microsoft.Playwright.MSTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace AiTeam.Tests.Playwright.Generated
+{
+    [TestClass]
+    public class PR108_規則管理頁面視覺截圖測試 : PageTest
+    {
+        private string _dashboardUrl = string.Empty;
+        private string _dashboardUser = string.Empty;
+        private string _dashboardPass = string.Empty;
+        private const string ScreenshotDir = "screenshots";
+
+        [TestInitialize]
+        public async Task 初始化測試環境()
+        {
+            _dashboardUrl = Environment.GetEnvironmentVariable("DASHBOARD_URL") ?? "http://localhost:5051";
+            _dashboardUser = Environment.GetEnvironmentVariable("DASHBOARD_USER") ?? string.Empty;
+            _dashboardPass = Environment.GetEnvironmentVariable("DASHBOARD_PASS") ?? string.Empty;
+
+            Directory.CreateDirectory(ScreenshotDir);
+
+            await 執行登入();
+        }
+
+        private async Task 執行登入()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/login");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+            var usernameInput = Page.Locator("input[type='text'], input[name='username'], input[name='email'], input[id*='user'], input[id*='email']").First;
+            var passwordInput = Page.Locator("input[type='password']").First;
+
+            if (await usernameInput.IsVisibleAsync())
+            {
+                await usernameInput.FillAsync(_dashboardUser);
+            }
+
+            if (await passwordInput.IsVisibleAsync())
+            {
+                await passwordInput.FillAsync(_dashboardPass);
+            }
+
+            var loginButton = Page.Locator("button[type='submit'], button:has-text('登入'), button:has-text('Login'), button:has-text('Sign in')").First;
+            if (await loginButton.IsVisibleAsync())
+            {
+                await loginButton.ClickAsync();
+            }
+
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        }
+
+        private async Task 切換暗色模式()
+        {
+            var darkModeToggle = Page.Locator(
+                "button[aria-label*='dark'], button[aria-label*='Dark'], " +
+                "button[aria-label*='暗色'], button[aria-label*='dark mode'], " +
+                "input[type='checkbox'][id*='dark'], input[type='checkbox'][id*='Dark'], " +
+                "[class*='dark-mode-toggle'], [class*='DarkModeToggle'], " +
+                "[class*='theme-toggle'], [class*='ThemeToggle'], " +
+                "button:has-text('Dark'), button:has-text('暗色'), " +
+                "button:has-text('🌙'), button:has-text('☀️'), " +
+                "[data-testid*='dark-mode'], [data-testid*='theme-toggle']"
+            ).First;
+
+            if (await darkModeToggle.IsVisibleAsync())
+            {
+                await darkModeToggle.ClickAsync();
+            }
+            else
+            {
+                await Page.EvaluateAsync(@"
+                    document.documentElement.classList.add('dark');
+                    document.documentElement.setAttribute('data-theme', 'dark');
+                    document.body.classList.add('dark-mode');
+                ");
+            }
+
+            await Page.WaitForTimeoutAsync(500);
+        }
+
+        // ── 規則管理頁面整體 ──────────────────────────────────────────────
+
+        [TestMethod]
+        public async Task 規則管理頁面_亮色模式_完整頁面截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/rules");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_light_full.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            var fileInfo = new FileInfo(screenshotPath);
+            Assert.IsTrue(fileInfo.Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 規則管理頁面_暗色模式_完整頁面截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/rules");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_dark_full.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            var fileInfo = new FileInfo(screenshotPath);
+            Assert.IsTrue(fileInfo.Length > 0, "截圖檔案不應為空");
+        }
+
+        // ── 頁面標題與操作按鈕 ───────────────────────────────────────────
+
+        [TestMethod]
+        public async Task 規則管理頁面_亮色模式_頁面標題與按鈕截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/rules");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var headerLocator = Page.Locator(".page-header").First;
+
+            string screenshotPath;
+            if (await headerLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_light_header.png");
+                await headerLocator.ScreenshotAsync(new LocatorScreenshotOptions
+                {
+                    Path = screenshotPath
+                });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_light_header_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions
+                {
+                    Path = screenshotPath,
+                    FullPage = false
+                });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            var fileInfo = new FileInfo(screenshotPath);
+            Assert.IsTrue(fileInfo.Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 規則管理頁面_暗色模式_頁面標題與按鈕截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/rules");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var headerLocator = Page.Locator(".page-header").First;
+
+            string screenshotPath;
+            if (await headerLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_dark_header.png");
+                await headerLocator.ScreenshotAsync(new LocatorScreenshotOptions
+                {
+                    Path = screenshotPath
+                });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_dark_header_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions
+                {
+                    Path = screenshotPath,
+                    FullPage = false
+                });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            var fileInfo = new FileInfo(screenshotPath);
+            Assert.IsTrue(fileInfo.Length > 0, "截圖檔案不應為空");
+        }
+
+        // ── 規則表格（含圖示按鈕操作欄）────────────────────────────────
+
+        [TestMethod]
+        public async Task 規則管理頁面_亮色模式_規則表格截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/rules");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var tableLocator = Page.Locator(".mud-table, table, [class*='MudTable']").First;
+
+            string screenshotPath;
+            if (await tableLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_light_table.png");
+                await tableLocator.ScreenshotAsync(new LocatorScreenshotOptions
+                {
+                    Path = screenshotPath
+                });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_light_table_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions
+                {
+                    Path = screenshotPath,
+                    FullPage = true
+                });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            var fileInfo = new FileInfo(screenshotPath);
+            Assert.IsTrue(fileInfo.Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 規則管理頁面_暗色模式_規則表格截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/rules");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var tableLocator = Page.Locator(".mud-table, table, [class*='MudTable']").First;
+
+            string screenshotPath;
+            if (await tableLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_dark_table.png");
+                await tableLocator.ScreenshotAsync(new LocatorScreenshotOptions
+                {
+                    Path = screenshotPath
+                });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_dark_table_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions
+                {
+                    Path = screenshotPath,
+                    FullPage = true
+                });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            var fileInfo = new FileInfo(screenshotPath);
+            Assert.IsTrue(fileInfo.Length > 0, "截圖檔案不應為空");
+        }
+
+        // ── 圖示按鈕（編輯 / 刪除）懸停提示 ────────────────────────────
+
+        [TestMethod]
+        public async Task 規則管理頁面_亮色模式_操作欄圖示按鈕截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/rules");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            // 嘗試定位第一列的操作欄（含編輯與刪除圖示按鈕）
+            var actionCellLocator = Page.Locator(".mud-table-row .mud-table-cell:last-child, tr td:last-child").First;
+
+            string screenshotPath;
+            if (await actionCellLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_light_action_icons.png");
+                await actionCellLocator.ScreenshotAsync(new LocatorScreenshotOptions
+                {
+                    Path = screenshotPath
+                });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_light_action_icons_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions
+                {
+                    Path = screenshotPath,
+                    FullPage = true
+                });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            var fileInfo = new FileInfo(screenshotPath);
+            Assert.IsTrue(fileInfo.Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 規則管理頁面_暗色模式_操作欄圖示按鈕截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/rules");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var actionCellLocator = Page.Locator(".mud-table-row .mud-table-cell:last-child, tr td:last-child").First;
+
+            string screenshotPath;
+            if (await actionCellLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_dark_action_icons.png");
+                await actionCellLocator.ScreenshotAsync(new LocatorScreenshotOptions
+                {
+                    Path = screenshotPath
+                });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_dark_action_icons_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions
+                {
+                    Path = screenshotPath,
+                    FullPage = true
+                });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            var fileInfo = new FileInfo(screenshotPath);
+            Assert.IsTrue(fileInfo.Length > 0, "截圖檔案不應為空");
+        }
+
+        // ── 空狀態畫面 ───────────────────────────────────────────────────
+
+        [TestMethod]
+        public async Task 規則管理頁面_亮色模式_空狀態截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/rules");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var emptyStateLocator = Page.Locator(".empty-state").First;
+
+            string screenshotPath;
+            if (await emptyStateLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_light_empty_state.png");
+                await emptyStateLocator.ScreenshotAsync(new LocatorScreenshotOptions
+                {
+                    Path = screenshotPath
+                });
+            }
+            else
+            {
+                // 規則存在時截全頁
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_light_empty_state_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions
+                {
+                    Path = screenshotPath,
+                    FullPage = true
+                });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            var fileInfo = new FileInfo(screenshotPath);
+            Assert.IsTrue(fileInfo.Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 規則管理頁面_暗色模式_空狀態截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/rules");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var emptyStateLocator = Page.Locator(".empty-state").First;
+
+            string screenshotPath;
+            if (await emptyStateLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_dark_empty_state.png");
+                await emptyStateLocator.ScreenshotAsync(new LocatorScreenshotOptions
+                {
+                    Path = screenshotPath
+                });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR108_RuleManagement_dark_empty_state_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions
+                {
+                    Path = screenshotPath,
+                    FullPage = true
+                });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            var fileInfo = new FileInfo(screenshotPath);
+            Assert.IsTrue(fileInfo.Length > 0, "截圖檔案不應為空");
+        }
+    }
+}


### PR DESCRIPTION
## 任務說明
規則管理頁面表格 UI 微調：移除狀態文字 + 操作改圖示按鈕（Dev）

## 變更摘要
對 RuleManagement.razor 做純 UI 調整：移除 MudSwitch 的 Label 屬性（啟用/停用文字），並將操作欄的 MudButton（編輯/刪除）改為包覆 MudTooltip 的 MudIconButton（Edit/Delete 圖示），同時將 MudStack Spacing 由 2 降為 1，使表格更緊湊。後端邏輯與事件繫結不變。

---
🤖 由 AiTeam Dev Agent（Claude Code）自動產出