### PR TITLE
流程追蹤頁面 PR 欄位改顯示 PR 編號，Mock 流程不顯示超連結（Dev）

### DIFF
--- a/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineList.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineList.razor
@@ -56,7 +56,14 @@
         <MudTd>
             @if (!string.IsNullOrEmpty(context.DevPrUrl))
             {
-                <MudLink Href="@context.DevPrUrl" Target="_blank">PR</MudLink>
+                @if (context.Title.Contains("[MOCK]"))
+                {
+                    <MudText Typo="Typo.body2">@ExtractPrNumber(context.DevPrUrl)</MudText>
+                }
+                else
+                {
+                    <MudLink Href="@context.DevPrUrl" Target="_blank">@ExtractPrNumber(context.DevPrUrl)</MudLink>
+                }
             }
         </MudTd>
     </RowTemplate>

--- a/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineList.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineList.razor.cs
@@ -152,6 +152,13 @@ public partial class PipelineList : IAsyncDisposable
         _                  => Color.Default
     };
 
+    private static string ExtractPrNumber(string? url)
+    {
+        if (string.IsNullOrEmpty(url)) return "PR";
+        var last = url.TrimEnd('/').Split('/')[^1];
+        return int.TryParse(last, out var num) ? $"#{num}" : "PR";
+    }
+
     #endregion
 
     #region IAsyncDisposable

--- a/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineView.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineView.razor
@@ -23,7 +23,14 @@
         <MudText Typo="Typo.caption" Class="ml-2">@Group.CreatedAt.ToLocalTime().ToString("yyyy/MM/dd HH:mm")</MudText>
         @if (!string.IsNullOrEmpty(Group.DevPrUrl))
         {
-            <MudLink Href="@Group.DevPrUrl" Target="_blank" Typo="Typo.caption" Class="ml-2">PR 連結</MudLink>
+            @if (Group.Title.Contains("[MOCK]"))
+            {
+                <MudText Typo="Typo.caption" Class="ml-2">@PrNumberText</MudText>
+            }
+            else
+            {
+                <MudLink Href="@Group.DevPrUrl" Target="_blank" Typo="Typo.caption" Class="ml-2">@PrNumberText</MudLink>
+            }
         }
     </div>
 </div>

--- a/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineView.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineView.razor.cs
@@ -248,6 +248,15 @@ public partial class PipelineView : IAsyncDisposable
         _                  => Group?.WorkflowType ?? ""
     };
 
+    private string PrNumberText => ExtractPrNumber(Group?.DevPrUrl);
+
+    private static string ExtractPrNumber(string? url)
+    {
+        if (string.IsNullOrEmpty(url)) return "PR";
+        var last = url.TrimEnd('/').Split('/')[^1];
+        return int.TryParse(last, out var num) ? $"#{num}" : "PR";
+    }
+
     #endregion
 }
 

--- a/src/AiTeam.Tests.Playwright/Generated/PR109/VisualTests.cs
+++ b/src/AiTeam.Tests.Playwright/Generated/PR109/VisualTests.cs
@@ -1,0 +1,347 @@
+using Microsoft.Playwright;
+using Microsoft.Playwright.MSTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace AiTeam.Tests.Playwright.Generated
+{
+    [TestClass]
+    public class PR109_流程追蹤頁面視覺截圖測試 : PageTest
+    {
+        private string _dashboardUrl  = string.Empty;
+        private string _dashboardUser = string.Empty;
+        private string _dashboardPass = string.Empty;
+        private const string ScreenshotDir = "screenshots";
+
+        [TestInitialize]
+        public async Task 初始化測試環境()
+        {
+            _dashboardUrl  = Environment.GetEnvironmentVariable("DASHBOARD_URL")  ?? "http://localhost:5051";
+            _dashboardUser = Environment.GetEnvironmentVariable("DASHBOARD_USER") ?? string.Empty;
+            _dashboardPass = Environment.GetEnvironmentVariable("DASHBOARD_PASS") ?? string.Empty;
+
+            Directory.CreateDirectory(ScreenshotDir);
+
+            await 執行登入();
+        }
+
+        private async Task 執行登入()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/login");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+            var usernameInput = Page.Locator(
+                "input[type='text'], input[name='username'], input[name='email'], " +
+                "input[id*='user'], input[id*='email']").First;
+            var passwordInput = Page.Locator("input[type='password']").First;
+
+            if (await usernameInput.IsVisibleAsync())
+                await usernameInput.FillAsync(_dashboardUser);
+
+            if (await passwordInput.IsVisibleAsync())
+                await passwordInput.FillAsync(_dashboardPass);
+
+            var loginButton = Page.Locator(
+                "button[type='submit'], button:has-text('登入'), " +
+                "button:has-text('Login'), button:has-text('Sign in')").First;
+
+            if (await loginButton.IsVisibleAsync())
+                await loginButton.ClickAsync();
+
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        }
+
+        private async Task 切換暗色模式()
+        {
+            var darkModeToggle = Page.Locator(
+                "button[aria-label*='dark'], button[aria-label*='Dark'], " +
+                "button[aria-label*='暗色'], button[aria-label*='dark mode'], " +
+                "input[type='checkbox'][id*='dark'], input[type='checkbox'][id*='Dark'], " +
+                "[class*='dark-mode-toggle'], [class*='DarkModeToggle'], " +
+                "[class*='theme-toggle'], [class*='ThemeToggle'], " +
+                "button:has-text('Dark'), button:has-text('暗色'), " +
+                "button:has-text('🌙'), button:has-text('☀️'), " +
+                "[data-testid*='dark-mode'], [data-testid*='theme-toggle']"
+            ).First;
+
+            if (await darkModeToggle.IsVisibleAsync())
+            {
+                await darkModeToggle.ClickAsync();
+            }
+            else
+            {
+                await Page.EvaluateAsync(@"
+                    document.documentElement.classList.add('dark');
+                    document.documentElement.setAttribute('data-theme', 'dark');
+                    document.body.classList.add('dark-mode');
+                ");
+            }
+
+            await Page.WaitForTimeoutAsync(500);
+        }
+
+        // ── 流程追蹤頁面整體截圖 ─────────────────────────────────────────
+
+        [TestMethod]
+        public async Task 流程追蹤頁面_亮色模式_完整頁面截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/pipeline");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineList_light_full.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path     = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 流程追蹤頁面_暗色模式_完整頁面截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/pipeline");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineList_dark_full.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path     = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        // ── 頁面標題 ─────────────────────────────────────────────────────
+
+        [TestMethod]
+        public async Task 流程追蹤頁面_亮色模式_頁面標題截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/pipeline");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var headerLocator = Page.Locator(".page-header").First;
+
+            string screenshotPath;
+            if (await headerLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineList_light_header.png");
+                await headerLocator.ScreenshotAsync(new LocatorScreenshotOptions { Path = screenshotPath });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineList_light_header_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = false });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 流程追蹤頁面_暗色模式_頁面標題截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/pipeline");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var headerLocator = Page.Locator(".page-header").First;
+
+            string screenshotPath;
+            if (await headerLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineList_dark_header.png");
+                await headerLocator.ScreenshotAsync(new LocatorScreenshotOptions { Path = screenshotPath });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineList_dark_header_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = false });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        // ── TaskGroup 表格（含 PR 欄改顯示 PR 編號） ─────────────────────
+
+        [TestMethod]
+        public async Task 流程追蹤頁面_亮色模式_任務群組表格截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/pipeline");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var tableLocator = Page.Locator(".mud-table, table, [class*='MudTable']").First;
+
+            string screenshotPath;
+            if (await tableLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineList_light_table.png");
+                await tableLocator.ScreenshotAsync(new LocatorScreenshotOptions { Path = screenshotPath });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineList_light_table_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = true });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 流程追蹤頁面_暗色模式_任務群組表格截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/pipeline");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var tableLocator = Page.Locator(".mud-table, table, [class*='MudTable']").First;
+
+            string screenshotPath;
+            if (await tableLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineList_dark_table.png");
+                await tableLocator.ScreenshotAsync(new LocatorScreenshotOptions { Path = screenshotPath });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineList_dark_table_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = true });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        // ── 狀態篩選器 ───────────────────────────────────────────────────
+
+        [TestMethod]
+        public async Task 流程追蹤頁面_亮色模式_狀態篩選器截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/pipeline");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var filtersLocator = Page.Locator(".page-filters").First;
+
+            string screenshotPath;
+            if (await filtersLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineList_light_filters.png");
+                await filtersLocator.ScreenshotAsync(new LocatorScreenshotOptions { Path = screenshotPath });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineList_light_filters_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = false });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 流程追蹤頁面_暗色模式_狀態篩選器截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/pipeline");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var filtersLocator = Page.Locator(".page-filters").First;
+
+            string screenshotPath;
+            if (await filtersLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineList_dark_filters.png");
+                await filtersLocator.ScreenshotAsync(new LocatorScreenshotOptions { Path = screenshotPath });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineList_dark_filters_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = false });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        // ── Pipeline Drawer（PipelineView 元件）─────────────────────────
+
+        [TestMethod]
+        public async Task 流程追蹤頁面_亮色模式_點擊第一列開啟Drawer截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/pipeline");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            // 嘗試點擊第一列以開啟 PipelineView Drawer
+            var firstRow = Page.Locator(".mud-table-row.cursor-pointer, .mud-table tbody tr").First;
+            if (await firstRow.IsVisibleAsync())
+            {
+                await firstRow.ClickAsync();
+                await Page.WaitForTimeoutAsync(1000);
+            }
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineView_light_drawer.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path     = screenshotPath,
+                FullPage = false
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 流程追蹤頁面_暗色模式_點擊第一列開啟Drawer截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/pipeline");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(500);
+
+            var firstRow = Page.Locator(".mud-table-row.cursor-pointer, .mud-table tbody tr").First;
+            if (await firstRow.IsVisibleAsync())
+            {
+                await firstRow.ClickAsync();
+                await Page.WaitForTimeoutAsync(1000);
+            }
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR109_PipelineView_dark_drawer.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path     = screenshotPath,
+                FullPage = false
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineListTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineListTests.cs
@@ -1,0 +1,207 @@
+using System.Reflection;
+using AiTeam.Dashboard.Components.Pages.Tasks;
+using FluentAssertions;
+using MudBlazor;
+using Xunit;
+
+namespace AiTeam.Dashboard.Components.Pages.Tasks.Tests;
+
+public class PipelineListTests
+{
+    // -----------------------------------------------------------------------
+    // 輔助：呼叫私有靜態方法
+    // -----------------------------------------------------------------------
+
+    private static string InvokeWorkflowTypeLabel(string? workflowType)
+    {
+        var method = typeof(PipelineList).GetMethod(
+            "WorkflowTypeLabel",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (string)method.Invoke(null, new object?[] { workflowType })!;
+    }
+
+    private static Color InvokeWorkflowTypeColor(string? workflowType)
+    {
+        var method = typeof(PipelineList).GetMethod(
+            "WorkflowTypeColor",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (Color)method.Invoke(null, new object?[] { workflowType })!;
+    }
+
+    private static string InvokeExtractPrNumber(string? url)
+    {
+        var method = typeof(PipelineList).GetMethod(
+            "ExtractPrNumber",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (string)method.Invoke(null, new object?[] { url })!;
+    }
+
+    // -----------------------------------------------------------------------
+    // WorkflowTypeLabel — 已知類型
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void WorkflowTypeLabel_新功能類型_應回傳中文新功能標籤()
+    {
+        var result = InvokeWorkflowTypeLabel("new_feature");
+
+        result.Should().Be("新功能");
+    }
+
+    [Fact]
+    public void WorkflowTypeLabel_BugFix類型_應回傳BugFix標籤()
+    {
+        var result = InvokeWorkflowTypeLabel("bug_fix");
+
+        result.Should().Be("Bug Fix");
+    }
+
+    [Fact]
+    public void WorkflowTypeLabel_技術改善類型_應回傳技術改善標籤()
+    {
+        var result = InvokeWorkflowTypeLabel("tech_improvement");
+
+        result.Should().Be("技術改善");
+    }
+
+    // -----------------------------------------------------------------------
+    // WorkflowTypeLabel — 邊界：未知類型與 null
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void WorkflowTypeLabel_未知類型_應回傳原始字串值()
+    {
+        var result = InvokeWorkflowTypeLabel("unknown_type");
+
+        result.Should().Be("unknown_type");
+    }
+
+    [Fact]
+    public void WorkflowTypeLabel_Null_應回傳空字串()
+    {
+        var result = InvokeWorkflowTypeLabel(null);
+
+        result.Should().Be("");
+    }
+
+    [Fact]
+    public void WorkflowTypeLabel_空字串_應回傳空字串()
+    {
+        var result = InvokeWorkflowTypeLabel("");
+
+        result.Should().Be("");
+    }
+
+    // -----------------------------------------------------------------------
+    // WorkflowTypeColor — 已知類型
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void WorkflowTypeColor_新功能類型_應回傳Primary顏色()
+    {
+        var result = InvokeWorkflowTypeColor("new_feature");
+
+        result.Should().Be(Color.Primary);
+    }
+
+    [Fact]
+    public void WorkflowTypeColor_BugFix類型_應回傳Warning顏色()
+    {
+        var result = InvokeWorkflowTypeColor("bug_fix");
+
+        result.Should().Be(Color.Warning);
+    }
+
+    [Fact]
+    public void WorkflowTypeColor_技術改善類型_應回傳Secondary顏色()
+    {
+        var result = InvokeWorkflowTypeColor("tech_improvement");
+
+        result.Should().Be(Color.Secondary);
+    }
+
+    // -----------------------------------------------------------------------
+    // WorkflowTypeColor — 邊界：未知類型與 null
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void WorkflowTypeColor_未知類型_應回傳Default顏色()
+    {
+        var result = InvokeWorkflowTypeColor("other");
+
+        result.Should().Be(Color.Default);
+    }
+
+    [Fact]
+    public void WorkflowTypeColor_Null_應回傳Default顏色()
+    {
+        var result = InvokeWorkflowTypeColor(null);
+
+        result.Should().Be(Color.Default);
+    }
+
+    // -----------------------------------------------------------------------
+    // ExtractPrNumber — 正常 URL
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ExtractPrNumber_標準GitHub_PR_URL_應回傳井號加數字()
+    {
+        var result = InvokeExtractPrNumber("https://github.com/org/repo/pull/109");
+
+        result.Should().Be("#109");
+    }
+
+    [Fact]
+    public void ExtractPrNumber_URL結尾含斜線_應正確解析PR編號()
+    {
+        var result = InvokeExtractPrNumber("https://github.com/org/repo/pull/42/");
+
+        result.Should().Be("#42");
+    }
+
+    [Fact]
+    public void ExtractPrNumber_單一數字路徑_應回傳井號加數字()
+    {
+        var result = InvokeExtractPrNumber("https://example.com/pulls/7");
+
+        result.Should().Be("#7");
+    }
+
+    // -----------------------------------------------------------------------
+    // ExtractPrNumber — 邊界：無效輸入
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ExtractPrNumber_Null_應回傳PR文字()
+    {
+        var result = InvokeExtractPrNumber(null);
+
+        result.Should().Be("PR");
+    }
+
+    [Fact]
+    public void ExtractPrNumber_空字串_應回傳PR文字()
+    {
+        var result = InvokeExtractPrNumber("");
+
+        result.Should().Be("PR");
+    }
+
+    [Fact]
+    public void ExtractPrNumber_URL結尾為非數字字串_應回傳PR文字()
+    {
+        var result = InvokeExtractPrNumber("https://github.com/org/repo/pull/abc");
+
+        result.Should().Be("PR");
+    }
+
+    [Fact]
+    public void ExtractPrNumber_URL結尾為純斜線_應回傳PR文字()
+    {
+        // TrimEnd('/') 後最後一段為 "pull"，非數字
+        var result = InvokeExtractPrNumber("https://github.com/org/repo/pull/");
+
+        result.Should().Be("PR");
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineViewTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineViewTests.cs
@@ -1,0 +1,367 @@
+using System;
+using System.Reflection;
+using AiTeam.Dashboard.Components.Pages.Tasks;
+using AiTeam.Shared.Dtos;
+using FluentAssertions;
+using MudBlazor;
+using Xunit;
+
+namespace AiTeam.Dashboard.Components.Pages.Tasks.Tests;
+
+public class PipelineViewTests
+{
+    // -----------------------------------------------------------------------
+    // 輔助：呼叫私有靜態方法
+    // -----------------------------------------------------------------------
+
+    private static string InvokeExtractPrNumber(string? url)
+    {
+        var method = typeof(PipelineView).GetMethod(
+            "ExtractPrNumber",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (string)method.Invoke(null, new object?[] { url })!;
+    }
+
+    private static string InvokeFormatDuration(TaskItemDto task)
+    {
+        var method = typeof(PipelineView).GetMethod(
+            "FormatDuration",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (string)method.Invoke(null, new object?[] { task })!;
+    }
+
+    private static bool InvokeIsCompleted(string status)
+    {
+        var method = typeof(PipelineView).GetMethod(
+            "IsCompleted",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (bool)method.Invoke(null, new object?[] { status })!;
+    }
+
+    private static bool InvokeIsFailed(string status)
+    {
+        var method = typeof(PipelineView).GetMethod(
+            "IsFailed",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (bool)method.Invoke(null, new object?[] { status })!;
+    }
+
+    private static bool InvokeIsRevision(string status)
+    {
+        var method = typeof(PipelineView).GetMethod(
+            "IsRevision",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (bool)method.Invoke(null, new object?[] { status })!;
+    }
+
+    private static Color InvokeGetLogColor(string status)
+    {
+        var method = typeof(PipelineView).GetMethod(
+            "GetLogColor",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (Color)method.Invoke(null, new object?[] { status })!;
+    }
+
+    // -----------------------------------------------------------------------
+    // ExtractPrNumber — 正常 URL
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ExtractPrNumber_標準GitHub_PR_URL_應回傳井號加數字()
+    {
+        var result = InvokeExtractPrNumber("https://github.com/org/repo/pull/109");
+
+        result.Should().Be("#109");
+    }
+
+    [Fact]
+    public void ExtractPrNumber_URL結尾含斜線_應正確解析PR編號()
+    {
+        var result = InvokeExtractPrNumber("https://github.com/org/repo/pull/55/");
+
+        result.Should().Be("#55");
+    }
+
+    // -----------------------------------------------------------------------
+    // ExtractPrNumber — 邊界
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ExtractPrNumber_Null_應回傳PR文字()
+    {
+        var result = InvokeExtractPrNumber(null);
+
+        result.Should().Be("PR");
+    }
+
+    [Fact]
+    public void ExtractPrNumber_空字串_應回傳PR文字()
+    {
+        var result = InvokeExtractPrNumber("");
+
+        result.Should().Be("PR");
+    }
+
+    [Fact]
+    public void ExtractPrNumber_URL結尾為非數字_應回傳PR文字()
+    {
+        var result = InvokeExtractPrNumber("https://github.com/org/repo/compare/main...feature");
+
+        result.Should().Be("PR");
+    }
+
+    // -----------------------------------------------------------------------
+    // FormatDuration — running 狀態
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void FormatDuration_狀態為running_應回傳進行中格式()
+    {
+        var task = new TaskItemDto
+        {
+            Status    = "running",
+            CreatedAt = DateTime.UtcNow.AddMinutes(-5)
+        };
+
+        var result = InvokeFormatDuration(task);
+
+        result.Should().StartWith("進行中（");
+        result.Should().EndWith(" 分）");
+    }
+
+    [Fact]
+    public void FormatDuration_狀態為running且CreatedAt為現在_應回傳零分()
+    {
+        var task = new TaskItemDto
+        {
+            Status    = "running",
+            CreatedAt = DateTime.UtcNow
+        };
+
+        var result = InvokeFormatDuration(task);
+
+        result.Should().StartWith("進行中（");
+    }
+
+    // -----------------------------------------------------------------------
+    // FormatDuration — Duration 為 null
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void FormatDuration_Duration為Null_應回傳空字串()
+    {
+        var task = new TaskItemDto
+        {
+            Status      = "pending",
+            CompletedAt = null
+        };
+
+        var result = InvokeFormatDuration(task);
+
+        result.Should().Be("");
+    }
+
+    // -----------------------------------------------------------------------
+    // FormatDuration — 各時間範圍
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void FormatDuration_Duration小於60秒_應回傳秒格式()
+    {
+        var now  = DateTime.UtcNow;
+        var task = new TaskItemDto
+        {
+            Status      = "done",
+            CreatedAt   = now.AddSeconds(-45),
+            CompletedAt = now
+        };
+
+        var result = InvokeFormatDuration(task);
+
+        result.Should().Be("45 秒");
+    }
+
+    [Fact]
+    public void FormatDuration_Duration為分鐘含秒_應回傳分秒格式()
+    {
+        var now  = DateTime.UtcNow;
+        var task = new TaskItemDto
+        {
+            Status      = "done",
+            CreatedAt   = now.AddSeconds(-(3 * 60 + 30)),
+            CompletedAt = now
+        };
+
+        var result = InvokeFormatDuration(task);
+
+        result.Should().Be("3 分 30 秒");
+    }
+
+    [Fact]
+    public void FormatDuration_Duration為整數分鐘_應回傳純分格式()
+    {
+        var now  = DateTime.UtcNow;
+        var task = new TaskItemDto
+        {
+            Status      = "done",
+            CreatedAt   = now.AddMinutes(-10),
+            CompletedAt = now
+        };
+
+        var result = InvokeFormatDuration(task);
+
+        result.Should().Be("10 分");
+    }
+
+    [Fact]
+    public void FormatDuration_Duration超過1小時含分鐘_應回傳時分格式()
+    {
+        var now  = DateTime.UtcNow;
+        var task = new TaskItemDto
+        {
+            Status      = "done",
+            CreatedAt   = now.AddHours(-1).AddMinutes(-15),
+            CompletedAt = now
+        };
+
+        var result = InvokeFormatDuration(task);
+
+        result.Should().Be("1 時 15 分");
+    }
+
+    [Fact]
+    public void FormatDuration_Duration為整數小時_應回傳純時格式()
+    {
+        var now  = DateTime.UtcNow;
+        var task = new TaskItemDto
+        {
+            Status      = "done",
+            CreatedAt   = now.AddHours(-2),
+            CompletedAt = now
+        };
+
+        var result = InvokeFormatDuration(task);
+
+        result.Should().Be("2 時");
+    }
+
+    // -----------------------------------------------------------------------
+    // IsCompleted
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("done")]
+    [InlineData("skipped")]
+    public void IsCompleted_完成類狀態_應回傳True(string status)
+    {
+        var result = InvokeIsCompleted(status);
+
+        result.Should().BeTrue(because: $"狀態 '{status}' 視為已完成");
+    }
+
+    [Theory]
+    [InlineData("running")]
+    [InlineData("failed")]
+    [InlineData("pending")]
+    [InlineData("revision")]
+    public void IsCompleted_非完成類狀態_應回傳False(string status)
+    {
+        var result = InvokeIsCompleted(status);
+
+        result.Should().BeFalse(because: $"狀態 '{status}' 不視為已完成");
+    }
+
+    // -----------------------------------------------------------------------
+    // IsFailed
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("failed")]
+    [InlineData("error")]
+    public void IsFailed_失敗類狀態_應回傳True(string status)
+    {
+        var result = InvokeIsFailed(status);
+
+        result.Should().BeTrue(because: $"狀態 '{status}' 視為失敗");
+    }
+
+    [Theory]
+    [InlineData("done")]
+    [InlineData("running")]
+    [InlineData("cancelled")]
+    public void IsFailed_非失敗類狀態_應回傳False(string status)
+    {
+        var result = InvokeIsFailed(status);
+
+        result.Should().BeFalse(because: $"狀態 '{status}' 不視為失敗");
+    }
+
+    // -----------------------------------------------------------------------
+    // IsRevision
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("revision")]
+    [InlineData("reviewing")]
+    public void IsRevision_修正類狀態_應回傳True(string status)
+    {
+        var result = InvokeIsRevision(status);
+
+        result.Should().BeTrue(because: $"狀態 '{status}' 視為修正中");
+    }
+
+    [Theory]
+    [InlineData("done")]
+    [InlineData("running")]
+    [InlineData("failed")]
+    public void IsRevision_非修正類狀態_應回傳False(string status)
+    {
+        var result = InvokeIsRevision(status);
+
+        result.Should().BeFalse(because: $"狀態 '{status}' 不視為修正中");
+    }
+
+    // -----------------------------------------------------------------------
+    // GetLogColor
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void GetLogColor_done狀態_應回傳Success顏色()
+    {
+        InvokeGetLogColor("done").Should().Be(Color.Success);
+    }
+
+    [Theory]
+    [InlineData("failed")]
+    [InlineData("error")]
+    public void GetLogColor_失敗類狀態_應回傳Error顏色(string status)
+    {
+        InvokeGetLogColor(status).Should().Be(Color.Error);
+    }
+
+    [Fact]
+    public void GetLogColor_running狀態_應回傳Info顏色()
+    {
+        InvokeGetLogColor("running").Should().Be(Color.Info);
+    }
+
+    [Theory]
+    [InlineData("revision")]
+    [InlineData("reviewing")]
+    public void GetLogColor_修正類狀態_應回傳Warning顏色(string status)
+    {
+        InvokeGetLogColor(status).Should().Be(Color.Warning);
+    }
+
+    [Fact]
+    public void GetLogColor_skipped狀態_應回傳Tertiary顏色()
+    {
+        InvokeGetLogColor("skipped").Should().Be(Color.Tertiary);
+    }
+
+    [Fact]
+    public void GetLogColor_未知狀態_應回傳Default顏色()
+    {
+        InvokeGetLogColor("unknown").Should().Be(Color.Default);
+    }
+}


### PR DESCRIPTION
## 任務說明
流程追蹤頁面 PR 欄位改顯示 PR 編號，Mock 流程不顯示超連結（Dev）

## 變更摘要
修改 PipelineList 與 PipelineView 兩個頁面的 PR 欄位顯示邏輯：將原本固定文字「PR」/「PR 連結」改為顯示從 DevPrUrl 解析出的 PR 編號（如 #123）；對於 Title 含 [MOCK] 的 Mock 流程，PR 編號以純文字呈現不加超連結，正常流程則維持超連結行為。新增 ExtractPrNumber helper method 處理 URL 解析與 fallback 邏輯。

---
🤖 由 AiTeam Dev Agent（Claude Code）自動產出