### PR TITLE
Dashboard 錯誤處理體驗優化：全域 Toast 通知補齊（Dev）

### DIFF
--- a/docs/ui-specs/dashboard-toast-dev.md
+++ b/docs/ui-specs/dashboard-toast-dev.md
@@ -1,0 +1,79 @@
+完成設計階段！讓我為你提供最終摘要：
+
+---
+
+## 🎉 FF 十七 — 全域 Toast 通知補齊 | 設計階段完成報告
+
+我已完成全面的 UI/UX 設計工作，產出 **4 份核心文檔**，涵蓋 UX 規格、API 定義、開發指南、操作點清單。
+
+### 📄 設計成果物
+
+存放於 `docs/design/` 資料夾：
+
+| 文檔 | 用途 | 關鍵內容 |
+|------|------|---------|
+| **FF_17_GlobalToastNotification_UXSpec.md** | UX 規格全景 | 場景決策樹、視覺設計、涵蓋範圍、無障礙規範 |
+| **DashboardNotificationService_API.md** | API 詳細定義 | Service 簽名、4 個核心方法、代碼示例、邊界情況 |
+| **MudAlert_Snackbar_QuickReference.md** | 開發者速查 | 決策流程圖、5 個代碼片段、訊息範本庫、檢查清單 |
+| **OperationPointsBreakdown_FF_17.md** | 操作點清單 | 25 個操作點、3 個 Batch 分工、工作量估算、Issue 編碼 |
+| **FF_17_DesignPhase_Summary.md** | 階段總結 | 決策確認、待決項、實作重點、風險預案 |
+
+---
+
+### 🎯 核心設計決策
+
+✅ **已確認（無異議）**：
+- 雙軌通知設計（MudAlert inline + Snackbar 浮層，互補不替代）
+- Service 簽名：`ShowSuccess` / `ShowError` / `ShowWarning`（語義明確）
+- 訊息規範：80 字元上限、消失時間分級（3s/4s/5s）
+- 生命週期：Scoped，無 Circuit 隔離問題
+
+⚠️ **待決策**：
+- SignalR 連線監控是否納入 MVP（推薦排除本次，後續 FF 三十六）
+
+---
+
+### 📊 操作點與分工
+
+**總計 25 個操作點** 分佈在：
+- **Batch 1（5-7 天，P0）**：SystemSettings、RuleManagement、ProjectManagement（12 點）
+- **Batch 2（2-3 天，P0）**：三個 Dialog 補充 API 失敗通知（3 點）
+- **Batch 3（1-2 天，P1）**：卡片元件、AgentSettings、TaskCenter 等（10+ 點）
+
+---
+
+### 🚀 實作前置
+
+進入 Dev 階段前，確認：
+1. DashboardNotificationService 已在 `Program.cs` 註冊為 Scoped
+2. 開發團隊已閱讀 **QuickReference**（開發快速參考）
+3. SignalR 決策已拍板
+4. 測試環境 Playwright 可用
+
+---
+
+### 📋 訊息範本（開發參考）
+
+**成功**：「已{動作}{物件}」→ `✓ 已新增規則『回應繁體中文』`  
+**失敗**：「{動作}失敗：{原因}」→ `✗ 新增失敗：規則名稱重複`  
+**警告**：「{狀態}」→ `⚠ 連線已斷開`
+
+---
+
+### ⏰ 預計里程碑
+
+- Dev 開始：2026-05-02
+- Batch 1-3 完成：2026-05-14
+- Testing + QA：2026-05-15～16
+- Christ 手動驗收：2026-05-17
+- **版本更新**：v3.32.0 → v3.33.0
+
+---
+
+### 🔑 關鍵文檔快速導航
+
+- **Cody（實作）**：先讀 `QuickReference` + `API.md` + `OperationPoints.md`
+- **Quinn（測試）**：先讀 UX Spec 的「場景決策樹」+ API 的「邊界情況」
+- **Christ（驗收）**：可略讀 Summary + 訊息範本
+
+所有文檔均已清晰標註責任人、工作量、測試需求，開發團隊可直接上手。設計階段完成，準備進入實作階段！

--- a/src/AiTeam.Dashboard/Components/Pages/Projects/ProjectManagement.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Projects/ProjectManagement.razor.cs
@@ -12,6 +12,9 @@ public partial class ProjectManagement
     [Inject]
     private IDialogService DialogService { get; set; } = null!;
 
+    [Inject]
+    private IDashboardNotificationService NotificationService { get; set; } = null!;
+
     #endregion
 
     #region Private Variables
@@ -46,13 +49,24 @@ public partial class ProjectManagement
         var result = await dialog.Result;
 
         if (result is { Canceled: false } && result.Data is ProjectDto created)
+        {
             _projects.Insert(0, created);
+            await NotificationService.ShowSuccessAsync("已新增專案");
+        }
     }
 
     private async Task ToggleIsActiveAsync(ProjectDto project, bool isActive)
     {
-        await ProjectService.ToggleProjectActiveAsync(project.Id, isActive);
-        project.IsActive = isActive;
+        try
+        {
+            await ProjectService.ToggleProjectActiveAsync(project.Id, isActive);
+            project.IsActive = isActive;
+            await NotificationService.ShowSuccessAsync($"專案已{(isActive ? "啟用" : "停用")}");
+        }
+        catch
+        {
+            await NotificationService.ShowErrorAsync("切換狀態失敗，請稍後重試");
+        }
     }
 
     #endregion

--- a/src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagement.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagement.razor.cs
@@ -13,7 +13,7 @@ public partial class RuleManagement
     private DashboardBotService BotService { get; set; } = null!;
 
     [Inject]
-    private ISnackbar Snackbar { get; set; } = null!;
+    private IDashboardNotificationService NotificationService { get; set; } = null!;
 
     [Inject]
     private IDialogService DialogService { get; set; } = null!;
@@ -76,8 +76,10 @@ public partial class RuleManagement
         _isReloading = true;
         var ok = await BotService.ReloadCacheAsync("rules");
         _isReloading = false;
-        Snackbar.Add(ok ? "已套用變更（規則快取已更新）" : "套用失敗，請確認 Bot 服務正常",
-            ok ? Severity.Success : Severity.Error);
+        if (ok)
+            await NotificationService.ShowSuccessAsync("已套用變更（規則快取已更新）");
+        else
+            await NotificationService.ShowErrorAsync("套用失敗，請確認 Bot 服務正常");
     }
 
     private List<(string Label, string Value)> GetDialogAgentOptions()
@@ -100,6 +102,7 @@ public partial class RuleManagement
         {
             _rules.Add(created);
             _rules = [.. _rules.OrderBy(r => r.SortOrder).ThenBy(r => r.CreatedAt)];
+            await NotificationService.ShowSuccessAsync("已新增規則");
         }
     }
 
@@ -115,19 +118,38 @@ public partial class RuleManagement
         var result = await dialog.Result;
 
         if (result is { Canceled: false })
+        {
             _rules = [.. _rules.OrderBy(r => r.SortOrder).ThenBy(r => r.CreatedAt)];
+            await NotificationService.ShowSuccessAsync("規則已更新");
+        }
     }
 
     private async Task ToggleActiveAsync(Rule rule, bool isActive)
     {
-        await RuleService.ToggleRuleActiveAsync(rule.Id, isActive);
-        rule.IsActive = isActive;
+        try
+        {
+            await RuleService.ToggleRuleActiveAsync(rule.Id, isActive);
+            rule.IsActive = isActive;
+            await NotificationService.ShowSuccessAsync($"規則已{(isActive ? "啟用" : "停用")}");
+        }
+        catch
+        {
+            await NotificationService.ShowErrorAsync("切換狀態失敗，請稍後重試");
+        }
     }
 
     private async Task DeleteRuleAsync(Guid id)
     {
-        await RuleService.DeleteRuleAsync(id);
-        _rules.RemoveAll(r => r.Id == id);
+        try
+        {
+            await RuleService.DeleteRuleAsync(id);
+            _rules.RemoveAll(r => r.Id == id);
+            await NotificationService.ShowSuccessAsync("規則已刪除");
+        }
+        catch
+        {
+            await NotificationService.ShowErrorAsync("刪除失敗，請稍後重試");
+        }
     }
 
     #endregion

--- a/src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettings.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettings.razor
@@ -14,11 +14,6 @@
     </MudButton>
 </div>
 
-@if (_saveMessage is not null)
-{
-    <MudAlert Severity="Severity.Success" Class="mb-3">@_saveMessage</MudAlert>
-}
-
 <h3 style="margin-bottom:16px">一般設定</h3>
 
 <div class="system-config-card">

--- a/src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettings.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettings.razor.cs
@@ -1,5 +1,3 @@
-using MudBlazor;
-
 namespace AiTeam.Dashboard.Components.Pages.Settings;
 
 public partial class SystemSettings
@@ -13,7 +11,7 @@ public partial class SystemSettings
     private DashboardBotService BotService { get; set; } = null!;
 
     [Inject]
-    private ISnackbar Snackbar { get; set; } = null!;
+    private IDashboardNotificationService NotificationService { get; set; } = null!;
 
     #endregion
 
@@ -35,7 +33,6 @@ public partial class SystemSettings
     private bool    _isSavingUserId;
     private bool    _isSavingMockDelay;
     private bool    _isSavingWorkflow;
-    private string? _saveMessage;
 
     #endregion
 
@@ -83,15 +80,29 @@ public partial class SystemSettings
     private async Task OnSkipCeoConfirmChanged(bool newValue)
     {
         _skipCeoConfirm = newValue;
-        await AppSettingsService.UpsertAsync("SkipCeoConfirm", _skipCeoConfirm.ToString().ToLower());
-        _saveMessage = $"「跳過 CEO 派工確認」已{(_skipCeoConfirm ? "啟用" : "停用")}，5 分鐘內自動生效";
+        try
+        {
+            await AppSettingsService.UpsertAsync("SkipCeoConfirm", _skipCeoConfirm.ToString().ToLower());
+            await NotificationService.ShowSuccessAsync($"「跳過 CEO 派工確認」已{(_skipCeoConfirm ? "啟用" : "停用")}，5 分鐘內自動生效");
+        }
+        catch
+        {
+            await NotificationService.ShowErrorAsync("儲存失敗，請稍後重試");
+        }
     }
 
     private async Task OnMockModeChanged(bool newValue)
     {
         _mockMode = newValue;
-        await AppSettingsService.UpsertAsync("MockMode", _mockMode.ToString().ToLower());
-        _saveMessage = $"「Mock Mode」已{(_mockMode ? "啟用" : "停用")}，5 分鐘內自動生效";
+        try
+        {
+            await AppSettingsService.UpsertAsync("MockMode", _mockMode.ToString().ToLower());
+            await NotificationService.ShowSuccessAsync($"「Mock Mode」已{(_mockMode ? "啟用" : "停用")}，5 分鐘內自動生效");
+        }
+        catch
+        {
+            await NotificationService.ShowErrorAsync("儲存失敗，請稍後重試");
+        }
     }
 
     private async Task SaveCeoChannelIdAsync()
@@ -99,14 +110,25 @@ public partial class SystemSettings
         var trimmed = _ceoChannelId.Trim();
         if (!IsValidSnowflakeId(trimmed))
         {
-            _saveMessage = "格式錯誤：Discord 頻道 ID 應為 17-20 位純數字";
+            await NotificationService.ShowErrorAsync("格式錯誤：Discord 頻道 ID 應為 17-20 位純數字");
             return;
         }
 
         _isSavingChannel = true;
-        await AppSettingsService.UpsertAsync("CeoDefaultChannelId", trimmed);
-        _isSavingChannel = false;
-        _saveMessage = $"CEO 指令預設頻道已更新{(string.IsNullOrWhiteSpace(trimmed) ? "（已清除）" : $"：{trimmed}")}";
+        try
+        {
+            await AppSettingsService.UpsertAsync("CeoDefaultChannelId", trimmed);
+            await NotificationService.ShowSuccessAsync(
+                $"CEO 指令預設頻道已更新{(string.IsNullOrWhiteSpace(trimmed) ? "（已清除）" : $"：{trimmed}")}");
+        }
+        catch
+        {
+            await NotificationService.ShowErrorAsync("儲存失敗，請稍後重試");
+        }
+        finally
+        {
+            _isSavingChannel = false;
+        }
     }
 
     private async Task SaveChristUserIdAsync()
@@ -114,14 +136,25 @@ public partial class SystemSettings
         var trimmed = _christUserId.Trim();
         if (!IsValidSnowflakeId(trimmed))
         {
-            _saveMessage = "格式錯誤：Discord User ID 應為 17-20 位純數字";
+            await NotificationService.ShowErrorAsync("格式錯誤：Discord User ID 應為 17-20 位純數字");
             return;
         }
 
         _isSavingUserId = true;
-        await AppSettingsService.UpsertAsync("ChristDiscordUserId", trimmed);
-        _isSavingUserId = false;
-        _saveMessage = $"Christ Discord User ID 已更新{(string.IsNullOrWhiteSpace(trimmed) ? "（已清除）" : $"：{trimmed}")}";
+        try
+        {
+            await AppSettingsService.UpsertAsync("ChristDiscordUserId", trimmed);
+            await NotificationService.ShowSuccessAsync(
+                $"Christ Discord User ID 已更新{(string.IsNullOrWhiteSpace(trimmed) ? "（已清除）" : $"：{trimmed}")}");
+        }
+        catch
+        {
+            await NotificationService.ShowErrorAsync("儲存失敗，請稍後重試");
+        }
+        finally
+        {
+            _isSavingUserId = false;
+        }
     }
 
     /// <summary>Discord Snowflake ID 格式驗證：空字串（代表清除）或 17-20 位純數字。</summary>
@@ -135,27 +168,49 @@ public partial class SystemSettings
     {
         if (!IsMockDelayValid())
         {
-            _saveMessage = "格式錯誤：需滿足 0 ≤ 最小 < 最大 ≤ 600000";
+            await NotificationService.ShowErrorAsync("格式錯誤：需滿足 0 ≤ 最小 < 最大 ≤ 600000");
             return;
         }
 
         _isSavingMockDelay = true;
-        await AppSettingsService.UpsertAsync("Mock:DelayMinMs", _mockDelayMin.ToString());
-        await AppSettingsService.UpsertAsync("Mock:DelayMaxMs", _mockDelayMax.ToString());
-        _isSavingMockDelay = false;
-        _saveMessage = $"Mock Mode 延遲範圍已更新：{_mockDelayMin}–{_mockDelayMax} ms（5 分鐘內自動生效）";
+        try
+        {
+            await AppSettingsService.UpsertAsync("Mock:DelayMinMs", _mockDelayMin.ToString());
+            await AppSettingsService.UpsertAsync("Mock:DelayMaxMs", _mockDelayMax.ToString());
+            await NotificationService.ShowSuccessAsync(
+                $"Mock Mode 延遲範圍已更新：{_mockDelayMin}–{_mockDelayMax} ms（5 分鐘內自動生效）");
+        }
+        catch
+        {
+            await NotificationService.ShowErrorAsync("儲存失敗，請稍後重試");
+        }
+        finally
+        {
+            _isSavingMockDelay = false;
+        }
     }
 
     private async Task SaveWorkflowRoundsAsync()
     {
         _isSavingWorkflow = true;
-        await AppSettingsService.UpsertAsync("Workflow:ReviewAppealMaxRounds",  _reviewAppealMaxRounds.ToString());
-        await AppSettingsService.UpsertAsync("Workflow:QaFixMaxRounds",         _qaFixMaxRounds.ToString());
-        await AppSettingsService.UpsertAsync("Workflow:DevPlanAppealMaxRounds", _devPlanAppealMaxRounds.ToString());
-        await AppSettingsService.UpsertAsync("Workflow:KickoffMaxRounds",       _kickoffMaxRounds.ToString());
-        await AppSettingsService.UpsertAsync("Workflow:DesignMeetingMaxRounds", _designMeetingMaxRounds.ToString());
-        _isSavingWorkflow = false;
-        _saveMessage = $"流程輪次上限已更新（Review={_reviewAppealMaxRounds} / QA={_qaFixMaxRounds} / DevPlan={_devPlanAppealMaxRounds} / Kickoff={_kickoffMaxRounds} / Design={_designMeetingMaxRounds}），5 分鐘內自動生效";
+        try
+        {
+            await AppSettingsService.UpsertAsync("Workflow:ReviewAppealMaxRounds",  _reviewAppealMaxRounds.ToString());
+            await AppSettingsService.UpsertAsync("Workflow:QaFixMaxRounds",         _qaFixMaxRounds.ToString());
+            await AppSettingsService.UpsertAsync("Workflow:DevPlanAppealMaxRounds", _devPlanAppealMaxRounds.ToString());
+            await AppSettingsService.UpsertAsync("Workflow:KickoffMaxRounds",       _kickoffMaxRounds.ToString());
+            await AppSettingsService.UpsertAsync("Workflow:DesignMeetingMaxRounds", _designMeetingMaxRounds.ToString());
+            await NotificationService.ShowSuccessAsync(
+                $"流程輪次已更新（Review={_reviewAppealMaxRounds} / QA={_qaFixMaxRounds} / DevPlan={_devPlanAppealMaxRounds} / Kickoff={_kickoffMaxRounds} / Design={_designMeetingMaxRounds}）");
+        }
+        catch
+        {
+            await NotificationService.ShowErrorAsync("儲存失敗，請稍後重試");
+        }
+        finally
+        {
+            _isSavingWorkflow = false;
+        }
     }
 
     private async Task ReloadCacheAsync()
@@ -163,8 +218,10 @@ public partial class SystemSettings
         _isReloading = true;
         var ok = await BotService.ReloadCacheAsync("all");
         _isReloading = false;
-        Snackbar.Add(ok ? "已套用變更（規則與系統設定快取已更新）" : "套用失敗，請確認 Bot 服務正常",
-            ok ? Severity.Success : Severity.Error);
+        if (ok)
+            await NotificationService.ShowSuccessAsync("已套用變更（規則與系統設定快取已更新）");
+        else
+            await NotificationService.ShowErrorAsync("套用失敗，請確認 Bot 服務正常");
     }
 
     #endregion

--- a/src/AiTeam.Dashboard/Program.cs
+++ b/src/AiTeam.Dashboard/Program.cs
@@ -65,6 +65,7 @@ builder.Services.AddScoped<DashboardAppSettingsService>();
 builder.Services.AddScoped<DashboardTokenService>();
 builder.Services.AddScoped<InteractionRespondService>();
 builder.Services.AddScoped<DashboardCeoCommandService>();
+builder.Services.AddScoped<IDashboardNotificationService, DashboardNotificationService>();
 builder.Services.AddHttpClient();
 
 var app = builder.Build();

--- a/src/AiTeam.Dashboard/Services/DashboardNotificationService.cs
+++ b/src/AiTeam.Dashboard/Services/DashboardNotificationService.cs
@@ -1,0 +1,31 @@
+using MudBlazor;
+
+namespace AiTeam.Dashboard.Services;
+
+public class DashboardNotificationService(ISnackbar snackbar) : IDashboardNotificationService
+{
+    private const int MaxMessageLength = 80;
+
+    public Task ShowSuccessAsync(string message, int durationMs = 3000)
+    {
+        snackbar.Add(Truncate(message), Severity.Success, options => options.VisibleStateDuration = durationMs);
+        return Task.CompletedTask;
+    }
+
+    public Task ShowErrorAsync(string message, int durationMs = 5000)
+    {
+        snackbar.Add(Truncate(message), Severity.Error, options => options.VisibleStateDuration = durationMs);
+        return Task.CompletedTask;
+    }
+
+    public Task ShowWarningAsync(string message, int durationMs = 4000)
+    {
+        snackbar.Add(Truncate(message), Severity.Warning, options => options.VisibleStateDuration = durationMs);
+        return Task.CompletedTask;
+    }
+
+    public void ClearAllToasts() => snackbar.Clear();
+
+    private static string Truncate(string message)
+        => message.Length > MaxMessageLength ? string.Concat(message.AsSpan(0, MaxMessageLength), "...") : message;
+}

--- a/src/AiTeam.Dashboard/Services/IDashboardNotificationService.cs
+++ b/src/AiTeam.Dashboard/Services/IDashboardNotificationService.cs
@@ -1,0 +1,9 @@
+namespace AiTeam.Dashboard.Services;
+
+public interface IDashboardNotificationService
+{
+    Task ShowSuccessAsync(string message, int durationMs = 3000);
+    Task ShowErrorAsync(string message, int durationMs = 5000);
+    Task ShowWarningAsync(string message, int durationMs = 4000);
+    void ClearAllToasts();
+}

--- a/src/AiTeam.Tests.Playwright/Generated/PR170/VisualTests.cs
+++ b/src/AiTeam.Tests.Playwright/Generated/PR170/VisualTests.cs
@@ -1,0 +1,236 @@
+using Microsoft.Playwright;
+using Microsoft.Playwright.MSTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace AiTeam.Tests.Playwright.Generated
+{
+    [TestClass]
+    public class PR170_系統設定頁面視覺截圖測試 : PageTest
+    {
+        private string _dashboardUrl  = string.Empty;
+        private string _dashboardUser = string.Empty;
+        private string _dashboardPass = string.Empty;
+        private const string ScreenshotDir = "screenshots";
+
+        [TestInitialize]
+        public async Task 初始化測試環境()
+        {
+            _dashboardUrl  = Environment.GetEnvironmentVariable("DASHBOARD_URL")  ?? "http://localhost:5051";
+            _dashboardUser = Environment.GetEnvironmentVariable("DASHBOARD_USER") ?? string.Empty;
+            _dashboardPass = Environment.GetEnvironmentVariable("DASHBOARD_PASS") ?? string.Empty;
+
+            Directory.CreateDirectory(ScreenshotDir);
+
+            await 執行登入();
+        }
+
+        private async Task 執行登入()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/login");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+            var usernameInput = Page.Locator(
+                "input[type='text'], input[name='username'], input[name='email'], " +
+                "input[id*='user'], input[id*='email']").First;
+            var passwordInput = Page.Locator("input[type='password']").First;
+
+            if (await usernameInput.IsVisibleAsync())
+                await usernameInput.FillAsync(_dashboardUser);
+
+            if (await passwordInput.IsVisibleAsync())
+                await passwordInput.FillAsync(_dashboardPass);
+
+            var loginButton = Page.Locator(
+                "button[type='submit'], button:has-text('登入'), " +
+                "button:has-text('Login'), button:has-text('Sign in')").First;
+
+            if (await loginButton.IsVisibleAsync())
+                await loginButton.ClickAsync();
+
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        }
+
+        private async Task 切換暗色模式()
+        {
+            var darkModeToggle = Page.Locator(
+                "button[aria-label*='dark'], button[aria-label*='Dark'], " +
+                "button[aria-label*='暗色'], button[aria-label*='dark mode'], " +
+                "input[type='checkbox'][id*='dark'], input[type='checkbox'][id*='Dark'], " +
+                "[class*='dark-mode-toggle'], [class*='DarkModeToggle'], " +
+                "[class*='theme-toggle'], [class*='ThemeToggle'], " +
+                "button:has-text('Dark'), button:has-text('暗色'), " +
+                "button:has-text('🌙'), button:has-text('☀️'), " +
+                "[data-testid*='dark-mode'], [data-testid*='theme-toggle']"
+            ).First;
+
+            if (await darkModeToggle.IsVisibleAsync())
+            {
+                await darkModeToggle.ClickAsync();
+            }
+            else
+            {
+                await Page.EvaluateAsync(@"
+                    document.documentElement.classList.add('dark');
+                    document.documentElement.setAttribute('data-theme', 'dark');
+                    document.body.classList.add('dark-mode');
+                ");
+            }
+
+            await Page.WaitForTimeoutAsync(500);
+        }
+
+        // ── 完整頁面截圖 ──────────────────────────────────────────────────────
+
+        [TestMethod]
+        public async Task 系統設定頁面_亮色模式_完整頁面截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/system-settings");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR170_SystemSettings_light_full.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path     = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 系統設定頁面_暗色模式_完整頁面截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/system-settings");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR170_SystemSettings_dark_full.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path     = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        // ── 頁面標題截圖 ──────────────────────────────────────────────────────
+
+        [TestMethod]
+        public async Task 系統設定頁面_亮色模式_頁面標題截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/system-settings");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var headerLocator = Page.Locator(".page-header").First;
+
+            string screenshotPath;
+            if (await headerLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR170_SystemSettings_light_header.png");
+                await headerLocator.ScreenshotAsync(new LocatorScreenshotOptions { Path = screenshotPath });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR170_SystemSettings_light_header_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = false });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 系統設定頁面_暗色模式_頁面標題截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/system-settings");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var headerLocator = Page.Locator(".page-header").First;
+
+            string screenshotPath;
+            if (await headerLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR170_SystemSettings_dark_header.png");
+                await headerLocator.ScreenshotAsync(new LocatorScreenshotOptions { Path = screenshotPath });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR170_SystemSettings_dark_header_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = false });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        // ── 一般設定區塊截圖 ──────────────────────────────────────────────────
+
+        [TestMethod]
+        public async Task 系統設定頁面_亮色模式_一般設定區塊截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/system-settings");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var cardLocator = Page.Locator(".system-config-card").First;
+
+            string screenshotPath;
+            if (await cardLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR170_SystemSettings_light_general.png");
+                await cardLocator.ScreenshotAsync(new LocatorScreenshotOptions { Path = screenshotPath });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR170_SystemSettings_light_general_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = false });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 系統設定頁面_暗色模式_一般設定區塊截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/system-settings");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var cardLocator = Page.Locator(".system-config-card").First;
+
+            string screenshotPath;
+            if (await cardLocator.IsVisibleAsync())
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR170_SystemSettings_dark_general.png");
+                await cardLocator.ScreenshotAsync(new LocatorScreenshotOptions { Path = screenshotPath });
+            }
+            else
+            {
+                screenshotPath = Path.Combine(ScreenshotDir, "PR170_SystemSettings_dark_general_fallback.png");
+                await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = false });
+            }
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Projects/ProjectManagementTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Projects/ProjectManagementTests.cs
@@ -1,0 +1,114 @@
+// 測試標的：AiTeam.Dashboard.Components.Pages.Projects.ProjectManagement
+// 驗證：grep 'class ProjectManagement' src/AiTeam.Dashboard/Components/Pages/Projects/ProjectManagement.razor.cs → 命中第 5 行
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using AiTeam.Dashboard.Components.Pages.Projects;
+using AiTeam.Shared.Dtos;
+using FluentAssertions;
+using MudBlazor;
+using Xunit;
+
+namespace AiTeam.Dashboard.Components.Pages.Projects.Tests;
+
+public class ProjectManagementTests
+{
+    private static ProjectManagement CreateInstance()
+        => Activator.CreateInstance<ProjectManagement>();
+
+    private static bool GetIsDrawerOpen(ProjectManagement instance)
+        => (bool)typeof(ProjectManagement)
+            .GetField("_isDrawerOpen", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(instance)!;
+
+    private static void SetIsDrawerOpen(ProjectManagement instance, bool value)
+        => typeof(ProjectManagement)
+            .GetField("_isDrawerOpen", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, value);
+
+    private static ProjectDto? GetSelectedProject(ProjectManagement instance)
+        => (ProjectDto?)typeof(ProjectManagement)
+            .GetField("_selectedProject", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(instance);
+
+    private static void InvokeCloseDrawer(ProjectManagement instance)
+        => typeof(ProjectManagement)
+            .GetMethod("CloseDrawer", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(instance, null);
+
+    private static async Task InvokeOnRowClickAsync(ProjectManagement instance, TableRowClickEventArgs<ProjectDto> args)
+    {
+        var method = typeof(ProjectManagement).GetMethod(
+            "OnRowClickAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        await (Task)method.Invoke(instance, new object[] { args })!;
+    }
+
+    // 繞過 TableRowClickEventArgs<T> 需要 MudTr 的建構子限制，使用 GetUninitializedObject 建立空白實例後設定 Item
+    private static TableRowClickEventArgs<ProjectDto> CreateArgs(ProjectDto? item)
+    {
+        var args = (TableRowClickEventArgs<ProjectDto>)
+            RuntimeHelpers.GetUninitializedObject(typeof(TableRowClickEventArgs<ProjectDto>));
+
+        var backingField =
+            typeof(TableRowClickEventArgs<ProjectDto>)
+                .GetField("<Item>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? typeof(TableRowClickEventArgs<ProjectDto>)
+                .GetFields(BindingFlags.NonPublic | BindingFlags.Instance)
+                .FirstOrDefault(f => f.Name.Contains("Item", StringComparison.OrdinalIgnoreCase));
+
+        backingField?.SetValue(args, item);
+        return args;
+    }
+
+    // ── CloseDrawer ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CloseDrawer_抽屜開啟時_設定為關閉狀態()
+    {
+        var instance = CreateInstance();
+        SetIsDrawerOpen(instance, true);
+
+        InvokeCloseDrawer(instance);
+
+        GetIsDrawerOpen(instance).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CloseDrawer_抽屜已關閉時_狀態保持關閉()
+    {
+        var instance = CreateInstance();
+        SetIsDrawerOpen(instance, false);
+
+        InvokeCloseDrawer(instance);
+
+        GetIsDrawerOpen(instance).Should().BeFalse();
+    }
+
+    // ── OnRowClickAsync ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task OnRowClickAsync_傳入非空專案項目_開啟抽屜並設定選中專案()
+    {
+        var instance = CreateInstance();
+        var project  = new ProjectDto { Id = Guid.NewGuid(), Name = "測試專案" };
+        var args     = CreateArgs(project);
+
+        await InvokeOnRowClickAsync(instance, args);
+
+        GetIsDrawerOpen(instance).Should().BeTrue();
+        GetSelectedProject(instance).Should().Be(project);
+    }
+
+    [Fact]
+    public async Task OnRowClickAsync_傳入空項目_不開啟抽屜並清除選中專案()
+    {
+        var instance = CreateInstance();
+        SetIsDrawerOpen(instance, true);
+        var args = CreateArgs(null);
+
+        await InvokeOnRowClickAsync(instance, args);
+
+        GetIsDrawerOpen(instance).Should().BeFalse();
+        GetSelectedProject(instance).Should().BeNull();
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagementTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagementTests.cs
@@ -1,0 +1,78 @@
+// 測試標的：AiTeam.Dashboard.Components.Pages.Rules.RuleManagement
+// 驗證：grep 'class RuleManagement' src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagement.razor.cs → 命中第 5 行
+
+using System.Reflection;
+using AiTeam.Dashboard.Components.Pages.Rules;
+using AiTeam.Shared.Constants;
+using FluentAssertions;
+using MudBlazor;
+using Xunit;
+
+namespace AiTeam.Dashboard.Components.Pages.Rules.Tests;
+
+public class RuleManagementTests
+{
+    private static Color InvokeGetAgentChipColor(string? agentName)
+    {
+        var method = typeof(RuleManagement).GetMethod(
+            "GetAgentChipColor",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (Color)method.Invoke(null, new object?[] { agentName })!;
+    }
+
+    [Fact]
+    public void GetAgentChipColor_CEO代理人_回傳Primary顏色()
+    {
+        var result = InvokeGetAgentChipColor(AgentNames.Ceo);
+
+        result.Should().Be(Color.Primary);
+    }
+
+    [Fact]
+    public void GetAgentChipColor_Dev代理人_回傳Info顏色()
+    {
+        var result = InvokeGetAgentChipColor(AgentNames.Dev);
+
+        result.Should().Be(Color.Info);
+    }
+
+    [Fact]
+    public void GetAgentChipColor_QA代理人_回傳Secondary顏色()
+    {
+        var result = InvokeGetAgentChipColor(AgentNames.Qa);
+
+        result.Should().Be(Color.Secondary);
+    }
+
+    [Fact]
+    public void GetAgentChipColor_Reviewer代理人_回傳Error顏色()
+    {
+        var result = InvokeGetAgentChipColor(AgentNames.Reviewer);
+
+        result.Should().Be(Color.Error);
+    }
+
+    [Fact]
+    public void GetAgentChipColor_Release代理人_回傳Success顏色()
+    {
+        var result = InvokeGetAgentChipColor(AgentNames.Release);
+
+        result.Should().Be(Color.Success);
+    }
+
+    [Fact]
+    public void GetAgentChipColor_Null代理人名稱_回傳Default顏色()
+    {
+        var result = InvokeGetAgentChipColor(null);
+
+        result.Should().Be(Color.Default);
+    }
+
+    [Fact]
+    public void GetAgentChipColor_未知代理人名稱_回傳Default顏色()
+    {
+        var result = InvokeGetAgentChipColor("UnknownAgent");
+
+        result.Should().Be(Color.Default);
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettingsTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettingsTests.cs
@@ -1,0 +1,135 @@
+// 測試標的：AiTeam.Dashboard.Components.Pages.Settings.SystemSettings
+// 驗證：grep 'class SystemSettings' src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettings.razor.cs → 命中第 3 行
+
+using System.Reflection;
+using AiTeam.Dashboard.Components.Pages.Settings;
+using FluentAssertions;
+using Xunit;
+
+namespace AiTeam.Dashboard.Components.Pages.Settings.Tests;
+
+public class SystemSettingsTests
+{
+    private static bool InvokeIsValidSnowflakeId(string value)
+    {
+        var method = typeof(SystemSettings).GetMethod(
+            "IsValidSnowflakeId",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (bool)method.Invoke(null, new object[] { value })!;
+    }
+
+    private static bool InvokeIsMockDelayValid(int delayMin, int delayMax)
+    {
+        var instance = Activator.CreateInstance<SystemSettings>();
+        typeof(SystemSettings)
+            .GetField("_mockDelayMin", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, delayMin);
+        typeof(SystemSettings)
+            .GetField("_mockDelayMax", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, delayMax);
+        var method = typeof(SystemSettings).GetMethod(
+            "IsMockDelayValid",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (bool)method.Invoke(instance, null)!;
+    }
+
+    // ── IsValidSnowflakeId ───────────────────────────────────────────────────
+
+    [Fact]
+    public void IsValidSnowflakeId_空字串_回傳True代表清除操作有效()
+    {
+        var result = InvokeIsValidSnowflakeId("");
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidSnowflakeId_17位數字_回傳True()
+    {
+        var result = InvokeIsValidSnowflakeId("12345678901234567");
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidSnowflakeId_20位數字_回傳True()
+    {
+        var result = InvokeIsValidSnowflakeId("12345678901234567890");
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidSnowflakeId_16位數字_回傳False過短()
+    {
+        var result = InvokeIsValidSnowflakeId("1234567890123456");
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidSnowflakeId_21位數字_回傳False過長()
+    {
+        var result = InvokeIsValidSnowflakeId("123456789012345678901");
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidSnowflakeId_含非數字字元_回傳False格式無效()
+    {
+        var result = InvokeIsValidSnowflakeId("1234567890abc456789");
+
+        result.Should().BeFalse();
+    }
+
+    // ── IsMockDelayValid ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsMockDelayValid_預設值30000至60000_回傳True()
+    {
+        var result = InvokeIsMockDelayValid(30000, 60000);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsMockDelayValid_最小值為負數_回傳False()
+    {
+        var result = InvokeIsMockDelayValid(-1, 60000);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsMockDelayValid_最大值等於最小值_回傳False()
+    {
+        var result = InvokeIsMockDelayValid(30000, 30000);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsMockDelayValid_最大值超過600000_回傳False()
+    {
+        var result = InvokeIsMockDelayValid(0, 600001);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsMockDelayValid_最小值0最大值1_回傳True邊界有效()
+    {
+        var result = InvokeIsMockDelayValid(0, 1);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsMockDelayValid_最小值0最大值600000_回傳True邊界有效()
+    {
+        var result = InvokeIsMockDelayValid(0, 600000);
+
+        result.Should().BeTrue();
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Services/DashboardNotificationServiceTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Services/DashboardNotificationServiceTests.cs
@@ -1,0 +1,101 @@
+// 測試標的：AiTeam.Dashboard.Services.DashboardNotificationService
+// 驗證：grep 'class DashboardNotificationService' src/AiTeam.Dashboard/Services/DashboardNotificationService.cs → 命中第 5 行
+
+using AiTeam.Dashboard.Services;
+using FluentAssertions;
+using MudBlazor;
+using NSubstitute;
+using Xunit;
+
+namespace AiTeam.Dashboard.Services.Tests;
+
+public class DashboardNotificationServiceTests
+{
+    private readonly ISnackbar _snackbar = Substitute.For<ISnackbar>();
+    private readonly DashboardNotificationService _svc;
+
+    public DashboardNotificationServiceTests()
+    {
+        _svc = new DashboardNotificationService(_snackbar);
+    }
+
+    [Fact]
+    public async Task ShowSuccessAsync_正常訊息_以Success嚴重性呼叫Snackbar()
+    {
+        await _svc.ShowSuccessAsync("已新增專案");
+
+        _snackbar.Received(1).Add(
+            "已新增專案",
+            Severity.Success,
+            Arg.Any<Action<SnackbarOptions>?>());
+    }
+
+    [Fact]
+    public async Task ShowSuccessAsync_超過80字元訊息_截斷至83字元後傳入Snackbar()
+    {
+        var longMsg = new string('A', 100);
+
+        await _svc.ShowSuccessAsync(longMsg);
+
+        _snackbar.Received(1).Add(
+            Arg.Is<string>(s => s.Length == 83 && s.EndsWith("...")),
+            Severity.Success,
+            Arg.Any<Action<SnackbarOptions>?>());
+    }
+
+    [Fact]
+    public async Task ShowErrorAsync_正常訊息_以Error嚴重性呼叫Snackbar()
+    {
+        await _svc.ShowErrorAsync("切換狀態失敗，請稍後重試");
+
+        _snackbar.Received(1).Add(
+            "切換狀態失敗，請稍後重試",
+            Severity.Error,
+            Arg.Any<Action<SnackbarOptions>?>());
+    }
+
+    [Fact]
+    public async Task ShowErrorAsync_超過80字元訊息_截斷至83字元後傳入Snackbar()
+    {
+        var longMsg = new string('E', 90);
+
+        await _svc.ShowErrorAsync(longMsg);
+
+        _snackbar.Received(1).Add(
+            Arg.Is<string>(s => s.Length == 83 && s.EndsWith("...")),
+            Severity.Error,
+            Arg.Any<Action<SnackbarOptions>?>());
+    }
+
+    [Fact]
+    public async Task ShowWarningAsync_正常訊息_以Warning嚴重性呼叫Snackbar()
+    {
+        await _svc.ShowWarningAsync("注意事項");
+
+        _snackbar.Received(1).Add(
+            "注意事項",
+            Severity.Warning,
+            Arg.Any<Action<SnackbarOptions>?>());
+    }
+
+    [Fact]
+    public async Task ShowWarningAsync_恰好80字元訊息_不截斷直接傳入Snackbar()
+    {
+        var exactMsg = new string('W', 80);
+
+        await _svc.ShowWarningAsync(exactMsg);
+
+        _snackbar.Received(1).Add(
+            Arg.Is<string>(s => s.Length == 80 && !s.EndsWith("...")),
+            Severity.Warning,
+            Arg.Any<Action<SnackbarOptions>?>());
+    }
+
+    [Fact]
+    public void ClearAllToasts_呼叫後_清除所有Snackbar()
+    {
+        _svc.ClearAllToasts();
+
+        _snackbar.Received(1).Clear();
+    }
+}


### PR DESCRIPTION
## 任務說明
Dashboard 錯誤處理體驗優化：全域 Toast 通知補齊（Dev）

## 變更摘要
建立 DashboardNotificationService（Wrap ISnackbar，提供 ShowSuccess/ShowError/ShowWarning 統一 API），於 Program.cs 註冊為 Scoped，並在 Batch 1 高風險頁面（SystemSettings、RuleManagement、ProjectManagement）補齊操作成功/失敗的 Toast 通知，清理 SystemSettings 既有的 _saveMessage 重複提示。

Closes #159
Closes #160
Closes #161
Closes #162
Closes #163
Closes #164
Closes #165
Closes #166
Closes #167
Closes #168
Closes #169

---
🤖 由 AiTeam Dev Agent（Claude Code）自動產出