### PR TITLE
Dashboard 全域錯誤通知 Toast 機制 - Phase 2: 修改 DashboardRuleService 和 DashboardAgentService，Delete/Toggle 改拋異常而非 silent return。（Dev）

### DIFF
--- a/docs/ui-specs/dashboard-toast-phase-2-dashboardruleservice-dashboardagentservice-delete-toggle-silent-return-dev.md
+++ b/docs/ui-specs/dashboard-toast-phase-2-dashboardruleservice-dashboardagentservice-delete-toggle-silent-return-dev.md
@@ -1,0 +1,109 @@
+完美！我已經完成 Dashboard 統一錯誤通知機制的 **完整 UI/UX 規格設計**。現在讓我為你總結一下產出物：
+
+## 📦 設計文件總覽
+
+我為此項目產出了 **4 份設計文件**（全部位於 `docs/design/`）：
+
+### 1. **Dashboard_Notification_System_Specification.md** 
+完整的規格設計文件（15 章節），包含：
+- ✅ **分層通知架構**：Dialog 驗證 → Inline Alert；頁面操作 → Toast
+- ✅ **操作流程圖**：Delete/Toggle 樂觀更新失敗的完整回滾邏輯
+- ✅ **異常類定義**：`RuleNotFoundException`、`AgentConfigurationException` 的規範
+- ✅ **INotificationService 介面設計**：Success/Warning/Error 三層反饋
+- ✅ **Component 層模板**：RuleManagement & AgentSettings 的 try-catch 完整代碼示例
+- ✅ **Dialog 驗證規範**：Inline Alert 的訊息清理邏輯
+- ✅ **MudBlazor 元件建議**：色彩、消失時間、位置等細節
+
+### 2. **Dashboard_Notification_Checklist.md**
+驗收檢查清單（8 個實施階段），用於進度追蹤：
+- ✅ **階段 1-2**：基礎建設 + Service 層異常策略
+- ✅ **階段 3-4**：Component try-catch + Dialog 驗證層
+- ✅ **階段 5**：6 個 Playwright E2E 測試案例（成功 3 + 失敗 3）
+- ✅ **階段 6-8**：編譯檢查、文檔更新、最終驗收
+- ✅ **簽核表**：各角色確認日期
+
+### 3. **Dashboard_Toast_Style_Reference.md**
+UI 樣式參考手冊（前端開發者速查手冊）：
+- ✅ **Toast 樣式規格**：Success/Error/Warning 的背景色、文字色、圖示、消失時間
+- ✅ **Inline Alert 樣式**：Dialog 內驗證提示的詳細樣式
+- ✅ **色彩對照表**：MudBlazor 色系 + 16 進位代碼
+- ✅ **字體與間距**：排版規範 + MudBlazor Class 對應
+- ✅ **可訪問性**：WCAG AA 對比度檢查表
+- ✅ **響應式設計**：Mobile/Tablet/Desktop 適應
+
+### 4. **README.md**
+設計文件索引與導覽：
+- ✅ **職能快速導覽**：設計師/開發者/測試者各自應讀的文件部分
+- ✅ **實施鏈路**：從 Kickoff 到最終驗收的 5 個階段
+- ✅ **設計決策記錄**：已確認 & 待確認的 8 個決策點
+- ✅ **常見問題解答**
+
+---
+
+## 🎯 設計重點
+
+### 核心分層邏輯（已細化）
+
+```
+Dialog 層（驗證失敗）
+    ├─ Inline MudAlert
+    ├─ 背景：#ffebee（淺紅）
+    ├─ 文字：#c62828（深紅）
+    ├─ 消失：不消失（用戶修正後清除）
+    └─ 例如：「規則內容為必填」
+
+Page 層（操作失敗）
+    ├─ Toast Snackbar
+    ├─ Success：3 秒消失，綠色
+    ├─ Error：5 秒消失，紅色
+    └─ 例如：「刪除失敗：規則不存在或已被刪除」
+```
+
+### 樂觀更新失敗處理（細節化）
+
+| 操作 | 成功 | 失敗 |
+|------|------|------|
+| **Delete** | 列表移除 + Success Toast | Service 拋 `RuleNotFoundException` → catch 後重新加載列表 + Error Toast |
+| **Toggle** | UI 即時更新 + Success Toast | Service 拋異常 → catch 後回滾狀態 + Error Toast |
+
+---
+
+## ✅ 使用方式
+
+### 設計師（Demi）- 驗收視覺效果時：
+1. 打開 `Specification.md` 確認分層邏輯
+2. 按 `Checklist.md` 的「視覺驗收」逐項檢查
+3. 疑問時查 `Style_Reference.md` 的色彩/間距
+
+### 開發者（Cody）- 實施過程中：
+1. 按 `Specification.md` 理解完整流程
+2. 邊開發邊按 `Checklist.md` 對應階段檢查
+3. 樣式疑問查 `Style_Reference.md`
+
+### 測試者（Quinn）- 編寫 Playwright 測試時：
+1. 讀 `Checklist.md` 的「階段 5：測試與驗收」
+2. 執行 6 個完整測試案例（3 成功 + 3 失敗）
+
+---
+
+## 📊 文件統計
+
+| 文件 | 長度 | 內容 |
+|------|------|------|
+| Specification.md | ~700 行 | 規格設計 + 流程圖 + 代碼模板 |
+| Checklist.md | ~500 行 | 8 階段檢查 + 6 測試案例 |
+| Style_Reference.md | ~600 行 | 樣式規格 + 色彩表 + A11y 標準 |
+| README.md | ~300 行 | 導覽 + 快速查詢 |
+| **總計** | **~2100 行** | 完整 UI/UX 設計套裝 |
+
+---
+
+## 🚀 後續步驟
+
+1. **Demi 簽核**：確認設計文件完整性 ✅
+2. **Cody 開始實施**：按 Specification 編寫代碼
+3. **進度追蹤**：按 Checklist 各階段逐項驗收
+4. **Quinn 準備測試**：編寫 6 個 Playwright 測試案例
+5. **最終驗收**：視覺 + 代碼品質 + 測試全過
+
+所有文件已就緒，可以開始技術實現了！

--- a/src/AiTeam.Dashboard/Services/DashboardAgentService.cs
+++ b/src/AiTeam.Dashboard/Services/DashboardAgentService.cs
@@ -1,6 +1,7 @@
 using AiTeam.Data;
 using AiTeam.Shared.Constants;
 using AiTeam.Shared.Dtos;
+using AiTeam.Shared.Exceptions;
 using AiTeam.Shared.ViewModels;
 using Microsoft.EntityFrameworkCore;
 
@@ -60,7 +61,7 @@ public class DashboardAgentService(AppDbContext db)
         CancellationToken cancellationToken = default)
     {
         var agent = await db.AgentConfigs.FindAsync([agentId], cancellationToken);
-        if (agent is null) return isActive;
+        if (agent is null) throw new AgentNotFoundException(agentId);
 
         agent.IsActive = isActive;
         await db.SaveChangesAsync(cancellationToken);
@@ -74,7 +75,7 @@ public class DashboardAgentService(AppDbContext db)
         CancellationToken cancellationToken = default)
     {
         var agent = await db.AgentConfigs.FindAsync([agentId], cancellationToken);
-        if (agent is null) return;
+        if (agent is null) throw new AgentNotFoundException(agentId);
         agent.TrustLevel = trustLevel;
         await db.SaveChangesAsync(cancellationToken);
     }

--- a/src/AiTeam.Dashboard/Services/DashboardRuleService.cs
+++ b/src/AiTeam.Dashboard/Services/DashboardRuleService.cs
@@ -1,4 +1,5 @@
 using AiTeam.Data;
+using AiTeam.Shared.Exceptions;
 using Microsoft.EntityFrameworkCore;
 
 namespace AiTeam.Dashboard.Services;
@@ -60,7 +61,7 @@ public class DashboardRuleService(AppDbContext db)
         CancellationToken cancellationToken = default)
     {
         var rule = await db.Rules.FindAsync([id], cancellationToken);
-        if (rule is null) return;
+        if (rule is null) throw new RuleNotFoundException(id);
         rule.IsActive = isActive;
         await db.SaveChangesAsync(cancellationToken);
     }
@@ -69,7 +70,7 @@ public class DashboardRuleService(AppDbContext db)
     public async Task DeleteRuleAsync(Guid id, CancellationToken cancellationToken = default)
     {
         var rule = await db.Rules.FindAsync([id], cancellationToken);
-        if (rule is null) return;
+        if (rule is null) throw new RuleNotFoundException(id);
         db.Rules.Remove(rule);
         await db.SaveChangesAsync(cancellationToken);
     }

--- a/src/AiTeam.Shared/Exceptions/DashboardExceptions.cs
+++ b/src/AiTeam.Shared/Exceptions/DashboardExceptions.cs
@@ -1,0 +1,7 @@
+namespace AiTeam.Shared.Exceptions;
+
+public class RuleNotFoundException(Guid id)
+    : Exception($"規則 ID {id} 不存在或已被刪除");
+
+public class AgentNotFoundException(Guid agentId)
+    : Exception($"Agent ID {agentId} 不存在");


### PR DESCRIPTION
## 任務說明
Dashboard 全域錯誤通知 Toast 機制 - Phase 2: 修改 DashboardRuleService 和 DashboardAgentService，Delete/Toggle 改拋異常而非 silent return。（Dev）

## 變更摘要
Phase 2 實作：新增 RuleNotFoundException 與 AgentNotFoundException 於 AiTeam.Shared/Exceptions，並修改 DashboardRuleService 的 ToggleRuleActiveAsync、DeleteRuleAsync，以及 DashboardAgentService 的 UpdateIsActiveAsync、UpdateTrustLevelAsync，將原本 null check 後的 silent return 改為拋出對應自訂異常，方法簽名維持不變，為 Phase 3 Component 層 try-catch 鋪路。

Closes #249
Closes #250

---
🤖 由 AiTeam Dev Agent（Claude Code）自動產出