### PR TITLE
Dashboard 全域錯誤通知 Toast 機制 - Phase 2: 修改 DashboardRuleService 和 DashboardAgentService，Delete/Toggle 改拋異常而非 silent return。（Dev_fix）

### DIFF
--- a/src/AiTeam.Dashboard/Services/DashboardAgentService.cs
+++ b/src/AiTeam.Dashboard/Services/DashboardAgentService.cs
@@ -59,8 +59,8 @@ public class DashboardAgentService(AppDbContext db)
         bool isActive,
         CancellationToken cancellationToken = default)
     {
-        var agent = await db.AgentConfigs.FindAsync([agentId], cancellationToken);
-        if (agent is null) return isActive;
+        var agent = await db.AgentConfigs.FindAsync([agentId], cancellationToken)
+            ?? throw new KeyNotFoundException($"找不到 Agent {agentId}");
 
         agent.IsActive = isActive;
         await db.SaveChangesAsync(cancellationToken);

--- a/src/AiTeam.Dashboard/Services/DashboardRuleService.cs
+++ b/src/AiTeam.Dashboard/Services/DashboardRuleService.cs
@@ -59,8 +59,8 @@ public class DashboardRuleService(AppDbContext db)
         bool isActive,
         CancellationToken cancellationToken = default)
     {
-        var rule = await db.Rules.FindAsync([id], cancellationToken);
-        if (rule is null) return;
+        var rule = await db.Rules.FindAsync([id], cancellationToken)
+            ?? throw new KeyNotFoundException($"找不到規則 {id}");
         rule.IsActive = isActive;
         await db.SaveChangesAsync(cancellationToken);
     }
@@ -68,8 +68,8 @@ public class DashboardRuleService(AppDbContext db)
     /// <summary>刪除規則。</summary>
     public async Task DeleteRuleAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        var rule = await db.Rules.FindAsync([id], cancellationToken);
-        if (rule is null) return;
+        var rule = await db.Rules.FindAsync([id], cancellationToken)
+            ?? throw new KeyNotFoundException($"找不到規則 {id}");
         db.Rules.Remove(rule);
         await db.SaveChangesAsync(cancellationToken);
     }


### PR DESCRIPTION
## 任務說明
Dashboard 全域錯誤通知 Toast 機制 - Phase 2: 修改 DashboardRuleService 和 DashboardAgentService，Delete/Toggle 改拋異常而非 silent return。（Dev_fix）

## 變更摘要
Phase 2：修改 DashboardRuleService 和 DashboardAgentService 的 Delete 與 Toggle 方法，將原本 silent return 的錯誤情境改為拋出例外，以便上層 UI 能透過全域錯誤通知 Toast 機制統一處理失敗訊息。

---
🤖 由 AiTeam Dev Agent（Claude Code）自動產出