### PR TITLE
Dashboard 全域錯誤通知 Toast 機制 - Phase 2: 修改 DashboardRuleService 和 DashboardAgentService，Delete/Toggle 改拋異常而非 silent return。（Dev_fix）

### DIFF
--- a/src/AiTeam.Dashboard/Services/DashboardAgentService.cs
+++ b/src/AiTeam.Dashboard/Services/DashboardAgentService.cs
@@ -59,9 +59,8 @@ public class DashboardAgentService(AppDbContext db)
         bool isActive,
         CancellationToken cancellationToken = default)
     {
-        var agent = await db.AgentConfigs.FindAsync([agentId], cancellationToken);
-        if (agent is null) return isActive;
-
+        var agent = await db.AgentConfigs.FindAsync([agentId], cancellationToken)
+            ?? throw new KeyNotFoundException($"Agent {agentId} not found.");
         agent.IsActive = isActive;
         await db.SaveChangesAsync(cancellationToken);
         return agent.IsActive;

--- a/src/AiTeam.Dashboard/Services/DashboardRuleService.cs
+++ b/src/AiTeam.Dashboard/Services/DashboardRuleService.cs
@@ -59,8 +59,8 @@ public class DashboardRuleService(AppDbContext db)
         bool isActive,
         CancellationToken cancellationToken = default)
     {
-        var rule = await db.Rules.FindAsync([id], cancellationToken);
-        if (rule is null) return;
+        var rule = await db.Rules.FindAsync([id], cancellationToken)
+            ?? throw new KeyNotFoundException($"Rule {id} not found.");
         rule.IsActive = isActive;
         await db.SaveChangesAsync(cancellationToken);
     }
@@ -68,8 +68,8 @@ public class DashboardRuleService(AppDbContext db)
     /// <summary>刪除規則。</summary>
     public async Task DeleteRuleAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        var rule = await db.Rules.FindAsync([id], cancellationToken);
-        if (rule is null) return;
+        var rule = await db.Rules.FindAsync([id], cancellationToken)
+            ?? throw new KeyNotFoundException($"Rule {id} not found.");
         db.Rules.Remove(rule);
         await db.SaveChangesAsync(cancellationToken);
     }


### PR DESCRIPTION
## 任務說明
Dashboard 全域錯誤通知 Toast 機制 - Phase 2: 修改 DashboardRuleService 和 DashboardAgentService，Delete/Toggle 改拋異常而非 silent return。（Dev_fix）

## 變更摘要
Phase 2：將 DashboardRuleService 與 DashboardAgentService 中 Delete/Toggle 操作的 silent return（吞異常或回傳 false）改為向上拋出異常，讓 UI 層可透過全域錯誤處理機制顯示 Toast 通知。僅修改生產程式碼，不變更測試檔案。

---
🤖 由 AiTeam Dev Agent（Claude Code）自動產出