### PR TITLE
[Petra v5] Victoria，我想要打磨一下 Dashboard 的錯誤處理體驗。

### DIFF
--- a/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettings.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettings.razor.cs
@@ -57,6 +57,7 @@ public partial class AgentSettings
         catch (Exception ex)
         {
             _loadError = ex.Message;
+            Snackbar.Add($"Agent 設定載入失敗：{ex.Message}", Severity.Error);
         }
     }
 

--- a/src/AiTeam.Dashboard/Components/Pages/Agents/Dialogs/AgentCreateDialog.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Agents/Dialogs/AgentCreateDialog.razor
@@ -37,6 +37,9 @@
     [Inject]
     private DashboardAgentService AgentService { get; set; } = null!;
 
+    [Inject]
+    private ISnackbar Snackbar { get; set; } = null!;
+
     private string  _name        = "";
     private string  _description = "";
     private int     _trustLevel  = 1;
@@ -50,6 +53,7 @@
         if (string.IsNullOrWhiteSpace(_name))
         {
             _error = "名稱不可為空白。";
+            Snackbar.Add(_error, Severity.Error);
             return;
         }
 
@@ -64,6 +68,7 @@
         catch (Exception ex)
         {
             _error = $"新增失敗：{ex.Message}";
+            Snackbar.Add(_error, Severity.Error);
         }
         finally
         {

--- a/src/AiTeam.Dashboard/Components/Pages/Home/QuickCommandCard.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Home/QuickCommandCard.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components.Forms;
+using MudBlazor;
 
 namespace AiTeam.Dashboard.Components.Pages.Home;
 
@@ -11,6 +12,9 @@ public partial class QuickCommandCard
 
     [Inject]
     private NavigationManager Navigation { get; set; } = null!;
+
+    [Inject]
+    private ISnackbar Snackbar { get; set; } = null!;
 
     #endregion
 
@@ -69,7 +73,10 @@ public partial class QuickCommandCard
         }
 
         if (messages.Count > 0)
+        {
             _error = string.Join("；", messages);
+            Snackbar.Add(_error, Severity.Warning);
+        }
 
         if (valid.Count != _selectedFiles.Count)
             _selectedFiles = valid.Count == 0 ? null : valid;
@@ -108,6 +115,7 @@ public partial class QuickCommandCard
                 catch
                 {
                     _error = $"讀取圖片「{file.Name}」失敗，請重試。";
+                    Snackbar.Add(_error, Severity.Error);
                     _isSubmitting = false;
                     return;
                 }
@@ -123,6 +131,7 @@ public partial class QuickCommandCard
         if (!result.Success)
         {
             _error = result.ErrorMessage;
+            Snackbar.Add(_error ?? "指令送出失敗，請重試。", Severity.Error);
             return;
         }
 

--- a/src/AiTeam.Dashboard/Components/Pages/Projects/ProjectCreateDialog.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Projects/ProjectCreateDialog.razor
@@ -38,6 +38,9 @@
     [Inject]
     private DashboardProjectService ProjectService { get; set; } = null!;
 
+    [Inject]
+    private ISnackbar Snackbar { get; set; } = null!;
+
     private string  _name      = "";
     private string  _repoUrl   = "";
     private string  _techStack = "";
@@ -51,6 +54,7 @@
         if (string.IsNullOrWhiteSpace(_name))
         {
             _error = "專案名稱為必填。";
+            Snackbar.Add(_error, Severity.Error);
             return;
         }
 
@@ -65,6 +69,7 @@
         catch (Exception ex)
         {
             _error = $"新增失敗：{ex.Message}";
+            Snackbar.Add(_error, Severity.Error);
         }
         finally
         {

--- a/src/AiTeam.Dashboard/Components/Pages/Rules/RuleFormDialog.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Rules/RuleFormDialog.razor
@@ -41,6 +41,9 @@
     [Inject]
     private DashboardRuleService RuleService { get; set; } = null!;
 
+    [Inject]
+    private ISnackbar Snackbar { get; set; } = null!;
+
     [Parameter]
     public Rule? EditingRule { get; set; }
 
@@ -77,6 +80,7 @@
         if (string.IsNullOrWhiteSpace(_content))
         {
             _error = "規則內容為必填。";
+            Snackbar.Add(_error, Severity.Error);
             return;
         }
 
@@ -102,6 +106,7 @@
         catch (Exception ex)
         {
             _error = $"操作失敗：{ex.Message}";
+            Snackbar.Add(_error, Severity.Error);
         }
         finally
         {

--- a/src/AiTeam.Dashboard/Program.cs
+++ b/src/AiTeam.Dashboard/Program.cs
@@ -1,5 +1,6 @@
 using AiTeam.Dashboard.Configuration;
 using AiTeam.Dashboard.Identity;
+using MudBlazor;
 using MudBlazor.Services;
 using AiTeam.Dashboard.Services;
 using AiTeam.Data;
@@ -23,7 +24,12 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 // MudBlazor
-builder.Services.AddMudServices();
+builder.Services.AddMudServices(config =>
+{
+    config.SnackbarConfiguration.PositionClass        = Defaults.Classes.Position.BottomRight;
+    config.SnackbarConfiguration.VisibleStateDuration = 4000;
+    config.SnackbarConfiguration.ShowCloseIcon        = true;
+});
 
 // SignalR（Hub 定義在 AiTeam.Data）
 builder.Services.AddSignalR();


### PR DESCRIPTION
## 任務
Victoria，我想要打磨一下 Dashboard 的錯誤處理體驗。

最近在用的時候發現一個問題：很多操作失敗時，錯誤訊息只會顯示在表單區塊裡，但我視線可能在別的地方（例如剛點完按鈕在等結果），就完全錯過了。

舉個例子：首頁那個快速下達指令卡，如果我打的指令違規，提示就會在送出區上面冒出來，但有時候我已經滑下去看其他東西了，根本沒注意到指令沒送出去。

我希望能改成：表單裡的提示保留（緊貼違規來源），但同時要有個東西通知我「剛剛失敗了」，類似右下角彈出來的那種 toast 提示，讓我視線在哪裡都會看到。兩個地方訊息一致，toast 大概 3-5 秒自動消失就好。

不只快速下達指令卡，我覺得整個 Dashboard 凡是有「儲存失敗 / 操作失敗」的地方（系統設定、操作中心、Agent 設定、規則管理之類），都應該照同樣方式打磨一下。具體哪些頁面要動、要不要抽共用元件，你跟團隊判斷。

## Petra 動態決策
- Capability / Skill 序列：`code_implementation | code_implementation | code_implementation | code_review | qa_testing`
- Workers / Talents dispatch 順序：Cody → Cody → Cody → Vera → Quinn

## Worker 完成 summary
- [Cody|code_implementation|outputLen=1929]
Build 通過，0 error。

---

<!-- IMPLEMENTATION_NOTE_START -->
## 實作說明

### 實作的 Issues
- 無（直接需求：Dashboard 操作失敗時雙通道錯誤提示 — 保留 inline MudAlert + 新增右下角 Snackbar toast）

### 關鍵決策
- **不抽共用元件**：6 個地方各自加一行 `Snackbar.Add(...)` 即可，抽共用層的收益低於維護成本
- **Snackbar 全域配置改為右下角 + 4s**：符合 Victoria 需求（3-5 秒），BottomRight 對應「右下角彈出」描述；同時讓既有 Success/Warning toast 也受益，不需要個別設定
- **Dialog 元件用 `[Inject]` 注入 ISnackbar**：與現有 Dialog 元件注入其他 Service 的模式一致（`@code` 塊內 `[Inject]`）
- **QuickCommandCard 圖片驗證用 `Severity.Warning`**：圖片被過濾是預期行為（會告知哪些被略過），不是操作失敗，用 Warning 語意更正確；送出失敗仍用 `Severity.Error`

### 偏離 Dev_plan 之處
- 無（直接實作，未走 Dev_plan 流程）

### 遇到的問題
- `Program.cs` 使用 `Defaults.Classes.Position.BottomRight` 時因只有 `using MudBlazor.Services` 而缺少 `using MudBlazor`，補加後 build 通過

### 修改的檔案清單
- `src/AiTeam.Dashboard/Program.cs`：加 `using MudBlazor;`，AddMudServices 設定 BottomRight + 4s visibility
- `src/AiTeam.Dashboard/Components/Pages/Home/QuickCommandCard.razor.cs`：注入 ISnackbar，在圖片驗證失敗（Warning）、圖片讀取失敗（Error）、指令送出失敗（Error）加 toast
- `src/AiTeam.Dashboard/Components/Pages/Agents/Dialogs/AgentCreateDialog.razor`：注入 ISnackbar，驗證失敗與建立失敗加 toast
- `src/AiTeam.Dashboard/Components/Pages/Rules/RuleFormDialog.razor`：注入 ISnackbar，驗證失敗與操作失敗加 toast
- `src/AiTeam.Dashboard/Components/Pages/Projects/ProjectCreateDialog.razor`：注入 ISnackbar，驗證失敗與建立失敗加 toast
- `src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettings.razor.cs`：補 OnInitializedAsync catch 的 load error toast

### 範圍對照表
| 任務點 | 對應檔案 | 狀態 |
|--------|---------|------|
| 快速下達指令卡（圖片驗證 / 讀取 / 送出失敗） | QuickCommandCard.razor.cs | ✓ |
| Agent 設定載入失敗 | AgentSettings.razor.cs | ✓ |
| 新增 Agent 對話框失敗 | AgentCreateDialog.razor | ✓ |
| 規則管理對話框失敗 | RuleFormDialog.razor | ✓ |
| 新增專案對話框失敗 | ProjectCreateDialog.razor | ✓ |
| 系統設定（儲存操作） | SystemSettings.razor.cs | ❌ 不適用（已有 Snackbar，無 inline _error 模式） |
| 操作中心（回覆操作） | InteractionCenter.razor.cs | ❌ 不適用（已有 Snackbar，無 inline _error 模式） |
<!-- IMPLEMENTATION_NOTE_END -->
- [Cody|code_implementation|outputLen=2569]
Build 通過，0 error，54 warnings（均為既有 NuGet 安全性警告，非本次修改引入）。

以下是本次實作的完整摘要：

---

## 實作摘要

**本次任務**：Dashboard 操作失敗時雙通道錯誤提示 — 保留 inline MudAlert + 新增右下角 Snackbar toast

### 修改檔案
- `Program.cs` — MudBlazor Snackbar 全域設定為右下角 + 4s 自動消失
- `QuickCommandCard.razor.cs` — 圖片驗證失敗（Warning）、圖片讀取失敗（Error）、指令送出失敗（Error）加 toast
- `AgentCreateDialog.razor` — 驗證失敗與建立失敗加 toast
- `RuleFormDialog.razor` — 驗證失敗與操作失敗加 toast
- `ProjectCreateDialog.razor` — 驗證失敗與建立失敗加 toast
- `AgentSettings.razor.cs` — 頁面載入失敗加 toast

### 範圍對照表
| 任務點 | 對應檔案 | 狀態 |
|--------|---------|------|
| 快速下達指令卡 | QuickCommandCard.razor.cs | ✓ |
| Agent 設定載入 | AgentSettings.razor.cs | ✓ |
| 新增 Agent 對話框 | AgentCreateDialog.razor | ✓ |
| 規則管理對話框 | RuleFormDialog.razor | ✓ |
| 新增專案對話框 | ProjectCreateDialog.razor | ✓ |
| 系統設定 | SystemSettings.razor.cs | ❌ 不適用（已有 Snackbar，無 inline _error 模式） |
| 操作中心 | InteractionCenter.razor.cs | ❌ 不適用（已有 Snackbar，無 inline _error 模式） |

---

<!-- IMPLEMENTATION_NOTE_START -->
## 實作說明

### 實作的 Issues
- 無（直接需求：Dashboard 操作失敗時雙通道錯誤提示 — 保留 inline MudAlert + 新增右下角 Snackbar toast）

### 關鍵決策
- **不抽共用元件**：各頁面各自加一行 `Snackbar.Add(...)` 即可，抽共用層的收益低於維護成本
- **Snackbar 全域配置改為右下角 + 4s**：符合需求（3-5 秒），BottomRight 對應「右下角彈出」描述；既有 Success/Warning toast 也受益
- **Dialog 元件用 `[Inject]` 注入 ISnackbar**：與現有 Dialog 元件注入其他 Service 的模式一致

### 偏離 Dev_plan 之處
- 無

### 遇到的問題
- `Program.cs` 需補加 `using MudBlazor;` 才能使用 `Defaults.Classes.Position.BottomRight`

### 修改的檔案清單
- `src/AiTeam.Dashboard/Program.cs`：加 `using MudBlazor;`，AddMudServices 設定 BottomRight + 4s visibility
- `src/AiTeam.Dashboard/Components/Pages/Home/QuickCommandCard.razor.cs`：注入 ISnackbar，三處失敗加 toast
- `src/AiTeam.Dashboard/Components/Pages/Agents/Dialogs/AgentCreateDialog.razor`：注入 ISnackbar，驗證失敗與建立失敗加 toast
- `src/AiTeam.Dashboard/Components/Pages/Rules/RuleFormDialog.razor`：注入 ISnackbar，驗證失敗與操作失敗加 toast
- `src/AiTeam.Dashboard/Components/Pages/Projects/ProjectCreateDialog.razor`：注入 ISnackbar，驗證失敗與建立失敗加 toast
- `src/AiTeam.Dashboard/Components/Pages/Agents/A...(truncated)
- [Cody|code_implementation|outputLen=2455]
Build 通過，0 error。

---

**實作完成摘要（for Petra finalize）**

**功能**：Dashboard 操作失敗時雙通道錯誤提示（inline MudAlert 保留 + 右下角 Snackbar toast）

**修改檔案（6 個）**：

| 檔案 | 變更內容 |
|------|---------|
| `Program.cs` | Snackbar 全域設定：BottomRight + 4s visibility |
| `QuickCommandCard.razor.cs` | 注入 ISnackbar，圖片驗證（Warning）/ 讀取（Error）/ 送出失敗（Error）加 toast |
| `AgentCreateDialog.razor` | 注入 ISnackbar，驗證失敗 + 建立失敗加 toast |
| `RuleFormDialog.razor` | 注入 ISnackbar，驗證失敗 + 操作失敗加 toast |
| `ProjectCreateDialog.razor` | 注入 ISnackbar，驗證失敗 + 建立失敗加 toast |
| `AgentSettings.razor.cs` | 頁面載入失敗加 toast |

**範圍對照表（廣範圍指令確認）**：

| 任務點 | 對應檔案 | 狀態 |
|--------|---------|------|
| 快速下達指令卡 | QuickCommandCard.razor.cs | ✓ |
| Agent 設定載入 | AgentSettings.razor.cs | ✓ |
| 新增 Agent 對話框 | AgentCreateDialog.razor | ✓ |
| 規則管理對話框 | RuleFormDialog.razor | ✓ |
| 新增專案對話框 | ProjectCreateDialog.razor | ✓ |
| 系統設定 | SystemSettings.razor.cs | ❌ 不適用（已有 Snackbar，無 inline _error 模式） |
| 操作中心 | InteractionCenter.razor.cs | ❌ 不適用（已有 Snackbar，無 inline _error 模式） |

<!-- IMPLEMENTATION_NOTE_START -->
## 實作說明

### 實作的 Issues
- 無（直接需求：Dashboard 操作失敗時雙通道錯誤提示）

### 關鍵決策
- **不抽共用元件**：各頁面各自加一行 `Snackbar.Add(...)` 即可，抽共用層的收益低於維護成本
- **Snackbar 全域配置改為 BottomRight + 4s**：符合需求（3-5 秒），既有 Success/Warning toast 也受益
- **Dialog 元件用 `[Inject]` 注入 ISnackbar**：與現有注入模式一致

### 偏離 Dev_plan 之處
- 無

### 遇到的問題
- `Program.cs` 需補加 `using MudBlazor;` 才能使用 `Defaults.Classes.Position.BottomRight`

### 修改的檔案清單
- `src/AiTeam.Dashboard/Program.cs`：加 `using MudBlazor;`，設定 BottomRight + 4s
- `src/AiTeam.Dashboard/Components/Pages/Home/QuickCommandCard.razor.cs`：三處失敗加 toast
- `src/AiTeam.Dashboard/Components/Pages/Agents/Dialogs/AgentCreateDialog.razor`：驗證失敗與建立失敗加 toast
- `src/AiTeam.Dashboard/Components/Pages/Rules/RuleFormDialog.razor`：驗證失敗與操作失敗加 toast
- `src/AiTeam.Dashboard/Components/Pages/Projects/ProjectCreateDialog.razor`：驗證失敗與建立失敗加 toast
- `src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettings.razor.cs`：載入失敗加 toast

### 範圍對照表
| 任務點 | 對應檔案 | 狀態 |
|--------|----...(truncated)
- [Vera|code_review|outputLen=801]
{"critical":[],"warning":[],"info":[],"summary":"本次 PR 僅在既有錯誤處理路徑（catch / validation return）中新增 Snackbar toast，程式碼正確、無引入新問題，可放行。","impact":"**直接影響（6 個檔案）**\n- `Program.cs`：全域 Snackbar 設定變更（BottomRight、4s、ShowCloseIcon），會影響 Dashboard 所有已存在的 Snackbar 呼叫（Success / Warning / Error），包含 `AgentSettings`、`SystemSettings`、`InteractionCenter` 等頁面既有 toast，行為由舊預設（TopCenter / 5s）改為新設定，屬預期副作用。\n- `AgentCreateDialog.razor`、`RuleFormDialog.razor`、`ProjectCreateDialog.razor`：三個 Dialog 的 `SubmitAsync` 均以 `try/catch` 包覆 `await` 呼叫，Server Circuit 安全。\n- `QuickCommandCard.razor.cs`：新增 Snackbar 呼叫皆在 catch 塊或 validation return 路徑，不影響現有非同步流程。\n- `AgentSettings.razor.cs`：`ISnackbar` 原已注入，新增一行在 `OnInitializedAsync` catch 中，無副作用。\n\n**潛在副作用**\n- 無 DB / Migration / API 介面變更，無擴散風險。\n- 全域 Snackbar 位置改變為視覺層副作用，不影響業務邏輯。"}
- [Quinn|qa_testing|outputLen=0]


---
🤖 由 AiTeam Petra Orchestrator（v5 動態架構 PoC）自動產出
