### PR TITLE
[Petra v5] Victoria，我想要打磨一下 Dashboard 的錯誤處理體驗。

### DIFF
--- a/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettings.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettings.razor
@@ -86,6 +86,11 @@ else
                     }
                     <MudDivider Class="mb-3" />
 
+                    @if (_formError is not null)
+                    {
+                        <MudAlert Severity="Severity.Error" Class="mb-3">@_formError</MudAlert>
+                    }
+
                     <div class="d-flex align-center justify-space-between mb-3">
                         <MudText Typo="Typo.body2">啟用狀態</MudText>
                         <MudSwitch T="bool"

--- a/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettings.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettings.razor.cs
@@ -37,6 +37,7 @@ public partial class AgentSettings
     private bool                  _isSavingLlm;
     private string?               _saveMessage;
     private string?               _loadError;
+    private string?               _formError;
 
     // 重啟 Bot
     private bool  _showRestartConfirm;
@@ -100,6 +101,7 @@ public partial class AgentSettings
     {
         _isSaving    = true;
         _saveMessage = null;
+        _formError   = null;
         try
         {
             await AgentService.UpdateTrustLevelAsync(agent.Id, _trustLevels[agent.Id]);
@@ -108,7 +110,8 @@ public partial class AgentSettings
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"信任等級儲存失敗：{ex.Message}", Severity.Error);
+            _formError = $"信任等級儲存失敗：{ex.Message}";
+            Snackbar.Add(_formError, Severity.Error);
         }
         finally
         {
@@ -168,6 +171,7 @@ public partial class AgentSettings
     {
         if (_isSavingLlm) return;
         _isSavingLlm = true;
+        _formError   = null;
         try
         {
             var ok = await AgentService.UpdateTokenLimitsAsync(
@@ -176,7 +180,8 @@ public partial class AgentSettings
                 agent.MonthlyTokenLimitK);
             if (!ok)
             {
-                Snackbar.Add($"{agent.Name} Token Limit 儲存失敗：查無 Agent", Severity.Error);
+                _formError = $"{agent.Name} Token Limit 儲存失敗：查無 Agent";
+                Snackbar.Add(_formError, Severity.Error);
                 return;
             }
             await BotService.ReloadCacheAsync("agent-config");
@@ -190,7 +195,8 @@ public partial class AgentSettings
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"儲存失敗：{ex.Message}", Severity.Error);
+            _formError = $"儲存失敗：{ex.Message}";
+            Snackbar.Add(_formError, Severity.Error);
         }
         finally
         {

--- a/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettings.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettings.razor.cs
@@ -70,6 +70,7 @@ public partial class AgentSettings
     {
         if (_isTogglingActive) return;
         _isTogglingActive = true;
+        _formError        = null;
         try
         {
             agent.IsActive = await AgentService.UpdateIsActiveAsync(agent.Id, newValue);
@@ -77,7 +78,8 @@ public partial class AgentSettings
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"{agent.Name} 狀態切換失敗：{ex.Message}", Severity.Error);
+            _formError = $"{agent.Name} 狀態切換失敗：{ex.Message}";
+            Snackbar.Add(_formError, Severity.Error);
         }
         finally
         {

--- a/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettings.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettings.razor.cs
@@ -209,26 +209,25 @@ public partial class AgentSettings
         if (_isSavingLlm) return;
         if (string.IsNullOrEmpty(agent.Provider) || string.IsNullOrEmpty(agent.Model)) return;
 
-        _isSavingLlm = true;
+        _isSavingLlm   = true;
+        _formError     = null;
         try
         {
             var ok = await AgentService.UpdateProviderModelAsync(agent.Id, agent.Provider, agent.Model);
             if (!ok)
             {
-                Snackbar.Add($"{agent.Name} 儲存失敗：查無 Agent", Severity.Error);
+                _formError = $"{agent.Name} 儲存失敗：查無 Agent";
+                Snackbar.Add(_formError, Severity.Error);
                 return;
             }
             // Stage 38：通知 Bot 端快取失效，下次任務立即生效（無需重啟）
             await BotService.ReloadCacheAsync("agent-config");
             Snackbar.Add($"{agent.Name}：Provider={agent.Provider}、Model={agent.Model} 已更新，Bot Cache 已刷新。", Severity.Success);
         }
-        catch (ArgumentException ex)
-        {
-            Snackbar.Add($"儲存失敗：{ex.Message}", Severity.Error);
-        }
         catch (Exception ex)
         {
-            Snackbar.Add($"儲存失敗：{ex.Message}", Severity.Error);
+            _formError = $"儲存失敗：{ex.Message}";
+            Snackbar.Add(_formError, Severity.Error);
         }
         finally
         {

--- a/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettings.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettings.razor.cs
@@ -57,6 +57,7 @@ public partial class AgentSettings
         catch (Exception ex)
         {
             _loadError = ex.Message;
+            Snackbar.Add($"Agent 設定載入失敗：{ex.Message}", Severity.Error);
         }
     }
 
@@ -68,11 +69,19 @@ public partial class AgentSettings
     {
         if (_isTogglingActive) return;
         _isTogglingActive = true;
-
-        agent.IsActive = await AgentService.UpdateIsActiveAsync(agent.Id, newValue);
-        _saveMessage = $"{agent.Name} 已{(agent.IsActive ? "啟用" : "停用")}";
-
-        _isTogglingActive = false;
+        try
+        {
+            agent.IsActive = await AgentService.UpdateIsActiveAsync(agent.Id, newValue);
+            _saveMessage = $"{agent.Name} 已{(agent.IsActive ? "啟用" : "停用")}";
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"{agent.Name} 狀態切換失敗：{ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isTogglingActive = false;
+        }
     }
 
     private async Task OpenCreateAgentDialogAsync()
@@ -91,21 +100,42 @@ public partial class AgentSettings
     {
         _isSaving    = true;
         _saveMessage = null;
-
-        await AgentService.UpdateTrustLevelAsync(agent.Id, _trustLevels[agent.Id]);
-        agent.TrustLevel = _trustLevels[agent.Id];
-
-        _saveMessage = $"{agent.Name} 信任等級已儲存為 Lv{_trustLevels[agent.Id]}";
-        _isSaving    = false;
+        try
+        {
+            await AgentService.UpdateTrustLevelAsync(agent.Id, _trustLevels[agent.Id]);
+            agent.TrustLevel = _trustLevels[agent.Id];
+            _saveMessage = $"{agent.Name} 信任等級已儲存為 Lv{_trustLevels[agent.Id]}";
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"信任等級儲存失敗：{ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isSaving = false;
+        }
     }
 
     private async Task RestartBotAsync()
     {
         _isRestarting = true;
-        var success = await BotService.RestartBotAsync();
-        _showRestartConfirm = false;
-        _saveMessage = success ? "Bot 重啟指令已送出，請稍候約 30 秒後確認上線狀態" : "重啟失敗，請確認 Bot 服務設定";
-        _isRestarting = false;
+        try
+        {
+            var success = await BotService.RestartBotAsync();
+            _showRestartConfirm = false;
+            if (success)
+                _saveMessage = "Bot 重啟指令已送出，請稍候約 30 秒後確認上線狀態";
+            else
+                Snackbar.Add("Bot 重啟失敗，請確認 Bot 服務設定", Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Bot 重啟失敗：{ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isRestarting = false;
+        }
     }
 
     /// <summary>

--- a/src/AiTeam.Dashboard/Components/Pages/Agents/Dialogs/AgentCreateDialog.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Agents/Dialogs/AgentCreateDialog.razor
@@ -37,6 +37,9 @@
     [Inject]
     private DashboardAgentService AgentService { get; set; } = null!;
 
+    [Inject]
+    private ISnackbar Snackbar { get; set; } = null!;
+
     private string  _name        = "";
     private string  _description = "";
     private int     _trustLevel  = 1;
@@ -50,6 +53,7 @@
         if (string.IsNullOrWhiteSpace(_name))
         {
             _error = "名稱不可為空白。";
+            Snackbar.Add(_error, Severity.Warning);
             return;
         }
 
@@ -64,6 +68,7 @@
         catch (Exception ex)
         {
             _error = $"新增失敗：{ex.Message}";
+            Snackbar.Add(_error, Severity.Error);
         }
         finally
         {

--- a/src/AiTeam.Dashboard/Components/Pages/Deployments/DeploymentHistory.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Deployments/DeploymentHistory.razor
@@ -8,6 +8,11 @@
     <h2>部署紀錄</h2>
 </div>
 
+@if (_loadError is not null)
+{
+    <MudAlert Severity="Severity.Error" Class="mb-3">@_loadError</MudAlert>
+}
+
 <MudTable Items="@_deployments"
           Dense="true"
           Hover="true"

--- a/src/AiTeam.Dashboard/Components/Pages/Deployments/DeploymentHistory.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Deployments/DeploymentHistory.razor.cs
@@ -9,6 +9,9 @@ public partial class DeploymentHistory
     [Inject]
     private DashboardTaskService TaskService { get; set; } = null!;
 
+    [Inject]
+    private ISnackbar Snackbar { get; set; } = null!;
+
     #endregion
 
     #region Private Variables
@@ -24,12 +27,19 @@ public partial class DeploymentHistory
 
     protected override async Task OnInitializedAsync()
     {
-        // 部署紀錄：篩選 Ops Agent 執行的任務
-        var result = await TaskService.GetTasksPagedAsync(pageSize: 200);
-        _deployments = result.Items
-            .Where(t => t.AssignedAgent == AiTeam.Shared.Constants.AgentNames.Ops
-                     || t.TriggeredBy == "GitHub")
-            .ToList();
+        try
+        {
+            // 部署紀錄：篩選 Ops Agent 執行的任務
+            var result = await TaskService.GetTasksPagedAsync(pageSize: 200);
+            _deployments = result.Items
+                .Where(t => t.AssignedAgent == AiTeam.Shared.Constants.AgentNames.Ops
+                         || t.TriggeredBy == "GitHub")
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"部署紀錄載入失敗：{ex.Message}", Severity.Error);
+        }
     }
 
     #endregion
@@ -41,8 +51,15 @@ public partial class DeploymentHistory
         _selectedTask = args.Item;
         if (_selectedTask is null) return;
 
-        _selectedLogs = await TaskService.GetTaskLogsAsync(_selectedTask.Id);
-        _isDrawerOpen = true;
+        try
+        {
+            _selectedLogs = await TaskService.GetTaskLogsAsync(_selectedTask.Id);
+            _isDrawerOpen = true;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"載入部署記錄失敗：{ex.Message}", Severity.Error);
+        }
     }
 
     #endregion

--- a/src/AiTeam.Dashboard/Components/Pages/Deployments/DeploymentHistory.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Deployments/DeploymentHistory.razor.cs
@@ -20,6 +20,7 @@ public partial class DeploymentHistory
     private TaskItemDto?      _selectedTask;
     private List<TaskLogDto>  _selectedLogs = [];
     private bool              _isDrawerOpen;
+    private string?           _loadError;
 
     #endregion
 
@@ -38,7 +39,8 @@ public partial class DeploymentHistory
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"部署紀錄載入失敗：{ex.Message}", Severity.Error);
+            _loadError = $"部署紀錄載入失敗：{ex.Message}";
+            Snackbar.Add(_loadError, Severity.Error);
         }
     }
 

--- a/src/AiTeam.Dashboard/Components/Pages/Home/Home.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Home/Home.razor.cs
@@ -29,6 +29,9 @@ public partial class Home : IAsyncDisposable
     [Inject]
     private ILogger<Home> Logger { get; set; } = null!;
 
+    [Inject]
+    private ISnackbar Snackbar { get; set; } = null!;
+
     #endregion
 
     #region Private Variables
@@ -45,9 +48,16 @@ public partial class Home : IAsyncDisposable
 
     protected override async Task OnInitializedAsync()
     {
-        _agentStatuses = await AgentService.GetAllAgentStatusesAsync();
-        _recentGroups  = await TaskService.GetRecentTaskGroupsAsync(limit: 10);
-        _agentQueues   = await TaskService.GetAgentQueuesAsync();
+        try
+        {
+            _agentStatuses = await AgentService.GetAllAgentStatusesAsync();
+            _recentGroups  = await TaskService.GetRecentTaskGroupsAsync(limit: 10);
+            _agentQueues   = await TaskService.GetAgentQueuesAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"首頁資料載入失敗：{ex.Message}", Severity.Error);
+        }
         await ConnectSignalRAsync();
     }
 
@@ -137,10 +147,12 @@ public partial class Home : IAsyncDisposable
             client.BaseAddress = new Uri(Navigation.BaseUri);
             var response = await client.PostAsync("/internal/agent-status/test", null);
             Logger.LogInformation("測試推送回應：{StatusCode}", response.StatusCode);
+            Snackbar.Add($"測試推送已送出（HTTP {(int)response.StatusCode}）", Severity.Success);
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "測試推送失敗");
+            Snackbar.Add($"測試推送失敗：{ex.Message}", Severity.Error);
         }
     }
 

--- a/src/AiTeam.Dashboard/Components/Pages/Home/QuickCommandCard.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Home/QuickCommandCard.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components.Forms;
+using MudBlazor;
 
 namespace AiTeam.Dashboard.Components.Pages.Home;
 
@@ -11,6 +12,9 @@ public partial class QuickCommandCard
 
     [Inject]
     private NavigationManager Navigation { get; set; } = null!;
+
+    [Inject]
+    private ISnackbar Snackbar { get; set; } = null!;
 
     #endregion
 
@@ -69,7 +73,10 @@ public partial class QuickCommandCard
         }
 
         if (messages.Count > 0)
+        {
             _error = string.Join("；", messages);
+            Snackbar.Add(_error, Severity.Warning);
+        }
 
         if (valid.Count != _selectedFiles.Count)
             _selectedFiles = valid.Count == 0 ? null : valid;
@@ -108,6 +115,7 @@ public partial class QuickCommandCard
                 catch
                 {
                     _error = $"讀取圖片「{file.Name}」失敗，請重試。";
+                    Snackbar.Add(_error, Severity.Error);
                     _isSubmitting = false;
                     return;
                 }
@@ -122,7 +130,8 @@ public partial class QuickCommandCard
 
         if (!result.Success)
         {
-            _error = result.ErrorMessage;
+            _error = result.ErrorMessage ?? "指令送出失敗，請稍後再試。";
+            Snackbar.Add(_error, Severity.Error);
             return;
         }
 

--- a/src/AiTeam.Dashboard/Components/Pages/Interactions/InteractionCenter.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Interactions/InteractionCenter.razor
@@ -14,6 +14,11 @@
     <MudProgressLinear Indeterminate="true" Color="Color.Primary" Class="mb-4" />
 }
 
+@if (_loadError is not null)
+{
+    <MudAlert Severity="Severity.Error" Class="mb-4">@_loadError</MudAlert>
+}
+
 @* 待處理區塊 *@
 <MudText Typo="Typo.h6" Class="mb-2">
     待處理

--- a/src/AiTeam.Dashboard/Components/Pages/Interactions/InteractionCenter.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Interactions/InteractionCenter.razor
@@ -80,6 +80,10 @@ else
 {
     <MudProgressLinear Indeterminate="true" Color="Color.Secondary" Class="mb-2" />
 }
+else if (_historyError is not null)
+{
+    <MudAlert Severity="Severity.Error" Class="mb-3">@_historyError</MudAlert>
+}
 else if (_historyItems.Count == 0)
 {
     <MudAlert Severity="Severity.Normal" Class="mb-4">

--- a/src/AiTeam.Dashboard/Components/Pages/Interactions/InteractionCenter.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Interactions/InteractionCenter.razor.cs
@@ -32,6 +32,7 @@ public partial class InteractionCenter : IAsyncDisposable
     private List<BossInteractionDto> _historyItems = [];
     private bool                     _isLoading    = true;
     private bool                     _historyLoading = false;
+    private string?                  _loadError;
 
     // 歷史紀錄篩選條件
     private string?    _typeFilter   = null;
@@ -61,9 +62,15 @@ public partial class InteractionCenter : IAsyncDisposable
     private async Task LoadAsync()
     {
         _isLoading = true;
+        _loadError = null;
         try
         {
             _pending = await TaskService.GetPendingInteractionsAsync();
+        }
+        catch (Exception ex)
+        {
+            _loadError = $"載入待處理項目失敗：{ex.Message}";
+            Snackbar.Add(_loadError, Severity.Error);
         }
         finally
         {
@@ -87,6 +94,10 @@ public partial class InteractionCenter : IAsyncDisposable
                 sourceFilter: string.IsNullOrEmpty(_sourceFilter) ? null : _sourceFilter,
                 from: from, to: to);
             _historyItems = items;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"載入歷史紀錄失敗：{ex.Message}", Severity.Error);
         }
         finally
         {

--- a/src/AiTeam.Dashboard/Components/Pages/Interactions/InteractionCenter.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Interactions/InteractionCenter.razor.cs
@@ -30,9 +30,10 @@ public partial class InteractionCenter : IAsyncDisposable
 
     private List<BossInteractionDto> _pending      = [];
     private List<BossInteractionDto> _historyItems = [];
-    private bool                     _isLoading    = true;
+    private bool                     _isLoading      = true;
     private bool                     _historyLoading = false;
     private string?                  _loadError;
+    private string?                  _historyError;
 
     // 歷史紀錄篩選條件
     private string?    _typeFilter   = null;
@@ -83,6 +84,7 @@ public partial class InteractionCenter : IAsyncDisposable
     private async Task LoadHistoryAsync()
     {
         _historyLoading = true;
+        _historyError   = null;
         await InvokeAsync(StateHasChanged);
         try
         {
@@ -97,7 +99,8 @@ public partial class InteractionCenter : IAsyncDisposable
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"載入歷史紀錄失敗：{ex.Message}", Severity.Error);
+            _historyError = $"載入歷史紀錄失敗：{ex.Message}";
+            Snackbar.Add(_historyError, Severity.Error);
         }
         finally
         {

--- a/src/AiTeam.Dashboard/Components/Pages/Projects/ProjectCreateDialog.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Projects/ProjectCreateDialog.razor
@@ -38,6 +38,9 @@
     [Inject]
     private DashboardProjectService ProjectService { get; set; } = null!;
 
+    [Inject]
+    private ISnackbar Snackbar { get; set; } = null!;
+
     private string  _name      = "";
     private string  _repoUrl   = "";
     private string  _techStack = "";
@@ -51,6 +54,7 @@
         if (string.IsNullOrWhiteSpace(_name))
         {
             _error = "專案名稱為必填。";
+            Snackbar.Add(_error, Severity.Warning);
             return;
         }
 
@@ -65,6 +69,7 @@
         catch (Exception ex)
         {
             _error = $"新增失敗：{ex.Message}";
+            Snackbar.Add(_error, Severity.Error);
         }
         finally
         {

--- a/src/AiTeam.Dashboard/Components/Pages/Projects/ProjectManagement.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Projects/ProjectManagement.razor
@@ -13,6 +13,11 @@
     </MudButton>
 </div>
 
+@if (_loadError is not null)
+{
+    <MudAlert Severity="Severity.Error" Class="mb-3">@_loadError</MudAlert>
+}
+
 <MudTable Items="@_projects"
           Dense="true"
           Hover="true"

--- a/src/AiTeam.Dashboard/Components/Pages/Projects/ProjectManagement.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Projects/ProjectManagement.razor.cs
@@ -12,6 +12,9 @@ public partial class ProjectManagement
     [Inject]
     private IDialogService DialogService { get; set; } = null!;
 
+    [Inject]
+    private ISnackbar Snackbar { get; set; } = null!;
+
     #endregion
 
     #region Private Variables
@@ -19,13 +22,24 @@ public partial class ProjectManagement
     private List<ProjectDto> _projects = [];
     private ProjectDto?      _selectedProject;
     private bool             _isDrawerOpen;
+    private string?          _loadError;
 
     #endregion
 
     #region Override Methods
 
     protected override async Task OnInitializedAsync()
-        => _projects = await ProjectService.GetAllProjectsAsync();
+    {
+        try
+        {
+            _projects = await ProjectService.GetAllProjectsAsync();
+        }
+        catch (Exception ex)
+        {
+            _loadError = $"專案清單載入失敗：{ex.Message}";
+            Snackbar.Add(_loadError, Severity.Error);
+        }
+    }
 
     #endregion
 
@@ -51,8 +65,15 @@ public partial class ProjectManagement
 
     private async Task ToggleIsActiveAsync(ProjectDto project, bool isActive)
     {
-        await ProjectService.ToggleProjectActiveAsync(project.Id, isActive);
-        project.IsActive = isActive;
+        try
+        {
+            await ProjectService.ToggleProjectActiveAsync(project.Id, isActive);
+            project.IsActive = isActive;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"狀態切換失敗：{ex.Message}", Severity.Error);
+        }
     }
 
     #endregion

--- a/src/AiTeam.Dashboard/Components/Pages/Rules/RuleFormDialog.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Rules/RuleFormDialog.razor
@@ -41,6 +41,9 @@
     [Inject]
     private DashboardRuleService RuleService { get; set; } = null!;
 
+    [Inject]
+    private ISnackbar Snackbar { get; set; } = null!;
+
     [Parameter]
     public Rule? EditingRule { get; set; }
 
@@ -77,6 +80,7 @@
         if (string.IsNullOrWhiteSpace(_content))
         {
             _error = "規則內容為必填。";
+            Snackbar.Add(_error, Severity.Warning);
             return;
         }
 
@@ -102,6 +106,7 @@
         catch (Exception ex)
         {
             _error = $"操作失敗：{ex.Message}";
+            Snackbar.Add(_error, Severity.Error);
         }
         finally
         {

--- a/src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagement.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagement.razor
@@ -21,7 +21,11 @@
     </MudStack>
 </div>
 
-@if (_rules.Count == 0)
+@if (_loadError is not null)
+{
+    <MudAlert Severity="Severity.Error" Class="mb-3">@_loadError</MudAlert>
+}
+else if (_rules.Count == 0)
 {
     <div class="empty-state">
         <div class="empty-state-icon"><MudIcon Icon="@Icons.Material.Filled.Assignment" Size="Size.Large" Color="Color.Default" /></div>

--- a/src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagement.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagement.razor.cs
@@ -65,7 +65,16 @@ public partial class RuleManagement
     #region Override Methods
 
     protected override async Task OnInitializedAsync()
-        => _rules = await RuleService.GetAllRulesAsync();
+    {
+        try
+        {
+            _rules = await RuleService.GetAllRulesAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"規則載入失敗：{ex.Message}", Severity.Error);
+        }
+    }
 
     #endregion
 
@@ -120,14 +129,28 @@ public partial class RuleManagement
 
     private async Task ToggleActiveAsync(Rule rule, bool isActive)
     {
-        await RuleService.ToggleRuleActiveAsync(rule.Id, isActive);
-        rule.IsActive = isActive;
+        try
+        {
+            await RuleService.ToggleRuleActiveAsync(rule.Id, isActive);
+            rule.IsActive = isActive;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"狀態切換失敗：{ex.Message}", Severity.Error);
+        }
     }
 
     private async Task DeleteRuleAsync(Guid id)
     {
-        await RuleService.DeleteRuleAsync(id);
-        _rules.RemoveAll(r => r.Id == id);
+        try
+        {
+            await RuleService.DeleteRuleAsync(id);
+            _rules.RemoveAll(r => r.Id == id);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"刪除失敗：{ex.Message}", Severity.Error);
+        }
     }
 
     #endregion

--- a/src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagement.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagement.razor.cs
@@ -59,6 +59,7 @@ public partial class RuleManagement
 
     private List<Rule> _rules    = [];
     private bool       _isReloading;
+    private string?    _loadError;
 
     #endregion
 
@@ -72,7 +73,8 @@ public partial class RuleManagement
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"規則載入失敗：{ex.Message}", Severity.Error);
+            _loadError = $"規則載入失敗：{ex.Message}";
+            Snackbar.Add(_loadError, Severity.Error);
         }
     }
 

--- a/src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettings.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettings.razor
@@ -18,6 +18,10 @@
 {
     <MudAlert Severity="Severity.Success" Class="mb-3">@_saveMessage</MudAlert>
 }
+@if (_saveError is not null)
+{
+    <MudAlert Severity="Severity.Error" Class="mb-3">@_saveError</MudAlert>
+}
 
 <h3 style="margin-bottom:16px">一般設定</h3>
 

--- a/src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettings.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettings.razor.cs
@@ -120,50 +120,106 @@ public partial class SystemSettings
     private async Task OnSkipCeoConfirmChanged(bool newValue)
     {
         _skipCeoConfirm = newValue;
-        await AppSettingsService.UpsertAsync("SkipCeoConfirm", _skipCeoConfirm.ToString().ToLower());
-        _saveMessage = $"「跳過 CEO 派工確認」已{(_skipCeoConfirm ? "啟用" : "停用")}，5 分鐘內自動生效";
+        try
+        {
+            await AppSettingsService.UpsertAsync("SkipCeoConfirm", _skipCeoConfirm.ToString().ToLower());
+            _saveMessage = $"「跳過 CEO 派工確認」已{(_skipCeoConfirm ? "啟用" : "停用")}，5 分鐘內自動生效";
+        }
+        catch (Exception ex)
+        {
+            _skipCeoConfirm = !newValue;
+            Snackbar.Add($"設定儲存失敗：{ex.Message}", Severity.Error);
+        }
     }
 
     private async Task OnMockModeChanged(bool newValue)
     {
         _mockMode = newValue;
-        await AppSettingsService.UpsertAsync("MockMode", _mockMode.ToString().ToLower());
-        _saveMessage = $"「Mock Mode」已{(_mockMode ? "啟用" : "停用")}，5 分鐘內自動生效";
+        try
+        {
+            await AppSettingsService.UpsertAsync("MockMode", _mockMode.ToString().ToLower());
+            _saveMessage = $"「Mock Mode」已{(_mockMode ? "啟用" : "停用")}，5 分鐘內自動生效";
+        }
+        catch (Exception ex)
+        {
+            _mockMode = !newValue;
+            Snackbar.Add($"設定儲存失敗：{ex.Message}", Severity.Error);
+        }
     }
 
     private async Task OnUseFrameworkAppealLoopChanged(bool newValue)
     {
         _useFrameworkAppealLoop = newValue;
-        await AppSettingsService.UpsertAsync("Workflow:UseFrameworkAppealLoop", _useFrameworkAppealLoop.ToString().ToLower());
-        _saveMessage = $"「MS Agent Framework Appeal Loop」已{(_useFrameworkAppealLoop ? "啟用" : "停用")}（v4 漸進遷移 Stage 49 首發），5 分鐘內自動生效";
+        try
+        {
+            await AppSettingsService.UpsertAsync("Workflow:UseFrameworkAppealLoop", _useFrameworkAppealLoop.ToString().ToLower());
+            _saveMessage = $"「MS Agent Framework Appeal Loop」已{(_useFrameworkAppealLoop ? "啟用" : "停用")}（v4 漸進遷移 Stage 49 首發），5 分鐘內自動生效";
+        }
+        catch (Exception ex)
+        {
+            _useFrameworkAppealLoop = !newValue;
+            Snackbar.Add($"設定儲存失敗：{ex.Message}", Severity.Error);
+        }
     }
 
     private async Task OnUseFrameworkKickoffChanged(bool newValue)
     {
         _useFrameworkKickoff = newValue;
-        await AppSettingsService.UpsertAsync("Workflow:UseFrameworkKickoff", _useFrameworkKickoff.ToString().ToLower());
-        _saveMessage = $"「MS Agent Framework Kickoff Meeting」已{(_useFrameworkKickoff ? "啟用" : "停用")}（v4 漸進遷移 Stage 50 第二步），5 分鐘內自動生效";
+        try
+        {
+            await AppSettingsService.UpsertAsync("Workflow:UseFrameworkKickoff", _useFrameworkKickoff.ToString().ToLower());
+            _saveMessage = $"「MS Agent Framework Kickoff Meeting」已{(_useFrameworkKickoff ? "啟用" : "停用")}（v4 漸進遷移 Stage 50 第二步），5 分鐘內自動生效";
+        }
+        catch (Exception ex)
+        {
+            _useFrameworkKickoff = !newValue;
+            Snackbar.Add($"設定儲存失敗：{ex.Message}", Severity.Error);
+        }
     }
 
     private async Task OnUseFrameworkKickoffMidInterruptChanged(bool newValue)
     {
         _useFrameworkKickoffMidInterrupt = newValue;
-        await AppSettingsService.UpsertAsync("Workflow:UseFrameworkKickoffMidInterrupt", _useFrameworkKickoffMidInterrupt.ToString().ToLower());
-        _saveMessage = $"「MS Agent Framework HITL（Kickoff 中途介入試點）」已{(_useFrameworkKickoffMidInterrupt ? "啟用" : "停用")}（v4 漸進遷移 Stage 51 第三步試點），5 分鐘內自動生效";
+        try
+        {
+            await AppSettingsService.UpsertAsync("Workflow:UseFrameworkKickoffMidInterrupt", _useFrameworkKickoffMidInterrupt.ToString().ToLower());
+            _saveMessage = $"「MS Agent Framework HITL（Kickoff 中途介入試點）」已{(_useFrameworkKickoffMidInterrupt ? "啟用" : "停用")}（v4 漸進遷移 Stage 51 第三步試點），5 分鐘內自動生效";
+        }
+        catch (Exception ex)
+        {
+            _useFrameworkKickoffMidInterrupt = !newValue;
+            Snackbar.Add($"設定儲存失敗：{ex.Message}", Severity.Error);
+        }
     }
 
     private async Task OnUseFrameworkDesignChanged(bool newValue)
     {
         _useFrameworkDesign = newValue;
-        await AppSettingsService.UpsertAsync("Workflow:UseFrameworkDesign", _useFrameworkDesign.ToString().ToLower());
-        _saveMessage = $"「MS Agent Framework Design Meeting」已{(_useFrameworkDesign ? "啟用" : "停用")}（v4 漸進遷移 Stage 52 第四步），5 分鐘內自動生效";
+        try
+        {
+            await AppSettingsService.UpsertAsync("Workflow:UseFrameworkDesign", _useFrameworkDesign.ToString().ToLower());
+            _saveMessage = $"「MS Agent Framework Design Meeting」已{(_useFrameworkDesign ? "啟用" : "停用")}（v4 漸進遷移 Stage 52 第四步），5 分鐘內自動生效";
+        }
+        catch (Exception ex)
+        {
+            _useFrameworkDesign = !newValue;
+            Snackbar.Add($"設定儲存失敗：{ex.Message}", Severity.Error);
+        }
     }
 
     private async Task OnUseFrameworkPipelineChanged(bool newValue)
     {
         _useFrameworkPipeline = newValue;
-        await AppSettingsService.UpsertAsync("Workflow:UseFrameworkPipeline", _useFrameworkPipeline.ToString().ToLower());
-        _saveMessage = $"「MS Agent Framework Pipeline」已{(_useFrameworkPipeline ? "啟用" : "停用")}（v4 漸進遷移 Stage 53A 第五步 macro-orchestration），5 分鐘內自動生效";
+        try
+        {
+            await AppSettingsService.UpsertAsync("Workflow:UseFrameworkPipeline", _useFrameworkPipeline.ToString().ToLower());
+            _saveMessage = $"「MS Agent Framework Pipeline」已{(_useFrameworkPipeline ? "啟用" : "停用")}（v4 漸進遷移 Stage 53A 第五步 macro-orchestration），5 分鐘內自動生效";
+        }
+        catch (Exception ex)
+        {
+            _useFrameworkPipeline = !newValue;
+            Snackbar.Add($"設定儲存失敗：{ex.Message}", Severity.Error);
+        }
     }
 
     private async Task SaveCeoChannelIdAsync()
@@ -178,10 +234,22 @@ public partial class SystemSettings
         }
 
         _isSavingChannel = true;
-        await AppSettingsService.UpsertAsync("CeoDefaultChannelId", trimmed);
-        _isSavingChannel = false;
-        _saveMessage = $"CEO 指令預設頻道已更新{(string.IsNullOrWhiteSpace(trimmed) ? "（已清除）" : $"：{trimmed}")}";
-        _saveError   = null;
+        try
+        {
+            await AppSettingsService.UpsertAsync("CeoDefaultChannelId", trimmed);
+            _saveMessage = $"CEO 指令預設頻道已更新{(string.IsNullOrWhiteSpace(trimmed) ? "（已清除）" : $"：{trimmed}")}";
+            _saveError   = null;
+        }
+        catch (Exception ex)
+        {
+            _saveError   = $"儲存失敗：{ex.Message}";
+            _saveMessage = null;
+            Snackbar.Add(_saveError, Severity.Error);
+        }
+        finally
+        {
+            _isSavingChannel = false;
+        }
     }
 
     private async Task SaveChristUserIdAsync()
@@ -196,10 +264,22 @@ public partial class SystemSettings
         }
 
         _isSavingUserId = true;
-        await AppSettingsService.UpsertAsync("ChristDiscordUserId", trimmed);
-        _isSavingUserId = false;
-        _saveMessage = $"Christ Discord User ID 已更新{(string.IsNullOrWhiteSpace(trimmed) ? "（已清除）" : $"：{trimmed}")}";
-        _saveError   = null;
+        try
+        {
+            await AppSettingsService.UpsertAsync("ChristDiscordUserId", trimmed);
+            _saveMessage = $"Christ Discord User ID 已更新{(string.IsNullOrWhiteSpace(trimmed) ? "（已清除）" : $"：{trimmed}")}";
+            _saveError   = null;
+        }
+        catch (Exception ex)
+        {
+            _saveError   = $"儲存失敗：{ex.Message}";
+            _saveMessage = null;
+            Snackbar.Add(_saveError, Severity.Error);
+        }
+        finally
+        {
+            _isSavingUserId = false;
+        }
     }
 
     /// <summary>Discord Snowflake ID 格式驗證：空字串（代表清除）或 17-20 位純數字。</summary>
@@ -220,23 +300,47 @@ public partial class SystemSettings
         }
 
         _isSavingMockDelay = true;
-        await AppSettingsService.UpsertAsync("Mock:DelayMinMs", _mockDelayMin.ToString());
-        await AppSettingsService.UpsertAsync("Mock:DelayMaxMs", _mockDelayMax.ToString());
-        _isSavingMockDelay = false;
-        _saveMessage = $"Mock Mode 延遲範圍已更新：{_mockDelayMin}–{_mockDelayMax} ms（5 分鐘內自動生效）";
-        _saveError   = null;
+        try
+        {
+            await AppSettingsService.UpsertAsync("Mock:DelayMinMs", _mockDelayMin.ToString());
+            await AppSettingsService.UpsertAsync("Mock:DelayMaxMs", _mockDelayMax.ToString());
+            _saveMessage = $"Mock Mode 延遲範圍已更新：{_mockDelayMin}–{_mockDelayMax} ms（5 分鐘內自動生效）";
+            _saveError   = null;
+        }
+        catch (Exception ex)
+        {
+            _saveError   = $"儲存失敗：{ex.Message}";
+            _saveMessage = null;
+            Snackbar.Add(_saveError, Severity.Error);
+        }
+        finally
+        {
+            _isSavingMockDelay = false;
+        }
     }
 
     private async Task SaveWorkflowRoundsAsync()
     {
         _isSavingWorkflow = true;
-        await AppSettingsService.UpsertAsync("Workflow:ReviewAppealMaxRounds",  _reviewAppealMaxRounds.ToString());
-        await AppSettingsService.UpsertAsync("Workflow:QaFixMaxRounds",         _qaFixMaxRounds.ToString());
-        await AppSettingsService.UpsertAsync("Workflow:DevPlanAppealMaxRounds", _devPlanAppealMaxRounds.ToString());
-        await AppSettingsService.UpsertAsync("Workflow:KickoffMaxRounds",       _kickoffMaxRounds.ToString());
-        await AppSettingsService.UpsertAsync("Workflow:DesignMeetingMaxRounds", _designMeetingMaxRounds.ToString());
-        _isSavingWorkflow = false;
-        _saveMessage = $"流程輪次上限已更新（Review={_reviewAppealMaxRounds} / QA={_qaFixMaxRounds} / DevPlan={_devPlanAppealMaxRounds} / Kickoff={_kickoffMaxRounds} / Design={_designMeetingMaxRounds}），5 分鐘內自動生效";
+        try
+        {
+            await AppSettingsService.UpsertAsync("Workflow:ReviewAppealMaxRounds",  _reviewAppealMaxRounds.ToString());
+            await AppSettingsService.UpsertAsync("Workflow:QaFixMaxRounds",         _qaFixMaxRounds.ToString());
+            await AppSettingsService.UpsertAsync("Workflow:DevPlanAppealMaxRounds", _devPlanAppealMaxRounds.ToString());
+            await AppSettingsService.UpsertAsync("Workflow:KickoffMaxRounds",       _kickoffMaxRounds.ToString());
+            await AppSettingsService.UpsertAsync("Workflow:DesignMeetingMaxRounds", _designMeetingMaxRounds.ToString());
+            _saveMessage = $"流程輪次上限已更新（Review={_reviewAppealMaxRounds} / QA={_qaFixMaxRounds} / DevPlan={_devPlanAppealMaxRounds} / Kickoff={_kickoffMaxRounds} / Design={_designMeetingMaxRounds}），5 分鐘內自動生效";
+        }
+        catch (Exception ex)
+        {
+            _saveError   = $"儲存失敗：{ex.Message}";
+            _saveMessage = null;
+            Snackbar.Add(_saveError, Severity.Error);
+        }
+        finally
+        {
+            _isSavingWorkflow = false;
+        }
     }
 
     private async Task SaveTokenLimitsAsync()
@@ -249,13 +353,25 @@ public partial class SystemSettings
             return;
         }
         _isSavingTokenLimits = true;
-        await AppSettingsService.UpsertAsync("Token:GlobalMonthlyLimitK", _globalMonthlyLimitK.ToString());
-        await AppSettingsService.UpsertAsync("Token:SingleRequestLimitK", _singleRequestLimitK.ToString());
-        // 立即刷新 Bot Cache，不需等 5 分鐘 TTL
-        await BotService.ReloadCacheAsync("all");
-        _isSavingTokenLimits = false;
-        _saveMessage = $"Token 守門設定已儲存（全域月限={_globalMonthlyLimitK}K / 單次上限={_singleRequestLimitK}K），Bot Cache 已立即刷新。";
-        _saveError   = null;
+        try
+        {
+            await AppSettingsService.UpsertAsync("Token:GlobalMonthlyLimitK", _globalMonthlyLimitK.ToString());
+            await AppSettingsService.UpsertAsync("Token:SingleRequestLimitK", _singleRequestLimitK.ToString());
+            // 立即刷新 Bot Cache，不需等 5 分鐘 TTL
+            await BotService.ReloadCacheAsync("all");
+            _saveMessage = $"Token 守門設定已儲存（全域月限={_globalMonthlyLimitK}K / 單次上限={_singleRequestLimitK}K），Bot Cache 已立即刷新。";
+            _saveError   = null;
+        }
+        catch (Exception ex)
+        {
+            _saveError   = $"儲存失敗：{ex.Message}";
+            _saveMessage = null;
+            Snackbar.Add(_saveError, Severity.Error);
+        }
+        finally
+        {
+            _isSavingTokenLimits = false;
+        }
     }
 
     private async Task ReloadCacheAsync()

--- a/src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettings.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettings.razor.cs
@@ -44,6 +44,7 @@ public partial class SystemSettings
     private bool    _isSavingMockDelay;
     private bool    _isSavingWorkflow;
     private string? _saveMessage;
+    private string? _saveError;
 
     #endregion
 
@@ -170,7 +171,9 @@ public partial class SystemSettings
         var trimmed = _ceoChannelId.Trim();
         if (!IsValidSnowflakeId(trimmed))
         {
-            _saveMessage = "格式錯誤：Discord 頻道 ID 應為 17-20 位純數字";
+            _saveError   = "格式錯誤：Discord 頻道 ID 應為 17-20 位純數字";
+            _saveMessage = null;
+            Snackbar.Add(_saveError, Severity.Warning);
             return;
         }
 
@@ -178,6 +181,7 @@ public partial class SystemSettings
         await AppSettingsService.UpsertAsync("CeoDefaultChannelId", trimmed);
         _isSavingChannel = false;
         _saveMessage = $"CEO 指令預設頻道已更新{(string.IsNullOrWhiteSpace(trimmed) ? "（已清除）" : $"：{trimmed}")}";
+        _saveError   = null;
     }
 
     private async Task SaveChristUserIdAsync()
@@ -185,7 +189,9 @@ public partial class SystemSettings
         var trimmed = _christUserId.Trim();
         if (!IsValidSnowflakeId(trimmed))
         {
-            _saveMessage = "格式錯誤：Discord User ID 應為 17-20 位純數字";
+            _saveError   = "格式錯誤：Discord User ID 應為 17-20 位純數字";
+            _saveMessage = null;
+            Snackbar.Add(_saveError, Severity.Warning);
             return;
         }
 
@@ -193,6 +199,7 @@ public partial class SystemSettings
         await AppSettingsService.UpsertAsync("ChristDiscordUserId", trimmed);
         _isSavingUserId = false;
         _saveMessage = $"Christ Discord User ID 已更新{(string.IsNullOrWhiteSpace(trimmed) ? "（已清除）" : $"：{trimmed}")}";
+        _saveError   = null;
     }
 
     /// <summary>Discord Snowflake ID 格式驗證：空字串（代表清除）或 17-20 位純數字。</summary>
@@ -206,7 +213,9 @@ public partial class SystemSettings
     {
         if (!IsMockDelayValid())
         {
-            _saveMessage = "格式錯誤：需滿足 0 ≤ 最小 < 最大 ≤ 600000";
+            _saveError   = "格式錯誤：需滿足 0 ≤ 最小 < 最大 ≤ 600000";
+            _saveMessage = null;
+            Snackbar.Add(_saveError, Severity.Warning);
             return;
         }
 
@@ -215,6 +224,7 @@ public partial class SystemSettings
         await AppSettingsService.UpsertAsync("Mock:DelayMaxMs", _mockDelayMax.ToString());
         _isSavingMockDelay = false;
         _saveMessage = $"Mock Mode 延遲範圍已更新：{_mockDelayMin}–{_mockDelayMax} ms（5 分鐘內自動生效）";
+        _saveError   = null;
     }
 
     private async Task SaveWorkflowRoundsAsync()
@@ -233,7 +243,9 @@ public partial class SystemSettings
     {
         if (_globalMonthlyLimitK <= 0 || _singleRequestLimitK <= 0)
         {
-            _saveMessage = "格式錯誤：Token 上限必須大於 0";
+            _saveError   = "格式錯誤：Token 上限必須大於 0";
+            _saveMessage = null;
+            Snackbar.Add(_saveError, Severity.Warning);
             return;
         }
         _isSavingTokenLimits = true;
@@ -243,6 +255,7 @@ public partial class SystemSettings
         await BotService.ReloadCacheAsync("all");
         _isSavingTokenLimits = false;
         _saveMessage = $"Token 守門設定已儲存（全域月限={_globalMonthlyLimitK}K / 單次上限={_singleRequestLimitK}K），Bot Cache 已立即刷新。";
+        _saveError   = null;
     }
 
     private async Task ReloadCacheAsync()

--- a/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineList.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineList.razor.cs
@@ -21,6 +21,9 @@ public partial class PipelineList : IAsyncDisposable
     [Inject]
     private IConfiguration Configuration { get; set; } = null!;
 
+    [Inject]
+    private ISnackbar Snackbar { get; set; } = null!;
+
     #endregion
 
     #region Private Variables
@@ -101,16 +104,24 @@ public partial class PipelineList : IAsyncDisposable
         TableState state,
         CancellationToken cancellationToken)
     {
-        var result = await TaskService.GetTaskGroupsPagedAsync(
-            page: state.Page + 1,
-            pageSize: state.PageSize,
-            statusFilters: _statusFilters.ToHashSet());
-
-        return new TableData<TaskGroupDto>
+        try
         {
-            Items      = result.Items,
-            TotalItems = result.TotalCount
-        };
+            var result = await TaskService.GetTaskGroupsPagedAsync(
+                page: state.Page + 1,
+                pageSize: state.PageSize,
+                statusFilters: _statusFilters.ToHashSet());
+
+            return new TableData<TaskGroupDto>
+            {
+                Items      = result.Items,
+                TotalItems = result.TotalCount
+            };
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"任務群組載入失敗：{ex.Message}", Severity.Error);
+            return new TableData<TaskGroupDto> { Items = [], TotalItems = 0 };
+        }
     }
 
     private void OnGroupRowClickAsync(TableRowClickEventArgs<TaskGroupDto> args)

--- a/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineView.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineView.razor.cs
@@ -159,6 +159,10 @@ public partial class PipelineView : IAsyncDisposable
             var runningIdx = _steps.FindIndex(s => s.Task.Status == "running");
             _activeStepIndex = runningIdx >= 0 ? runningIdx : Math.Max(0, _steps.Count - 1);
         }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Pipeline 步驟載入失敗：{ex.Message}", Severity.Error);
+        }
         finally
         {
             _loading = false;
@@ -169,8 +173,15 @@ public partial class PipelineView : IAsyncDisposable
     private async Task RefreshGroupContentAsync()
     {
         if (Group is null) return;
-        var freshGroup = await TaskService.GetTaskGroupByIdAsync(Group.Id);
-        ApplyGroupContent(freshGroup);
+        try
+        {
+            var freshGroup = await TaskService.GetTaskGroupByIdAsync(Group.Id);
+            ApplyGroupContent(freshGroup);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"群組內容更新失敗：{ex.Message}", Severity.Error);
+        }
     }
 
     /// <summary>將 freshGroup 的 content 欄位同步回 Group Parameter（集中管理，避免漏欄位）。</summary>
@@ -304,8 +315,15 @@ public partial class PipelineView : IAsyncDisposable
 
     private async Task LoadLogsAsync(PipelineStepViewModel step)
     {
-        step.Logs       = await TaskService.GetTaskLogsAsync(step.Task.Id);
-        step.LogsLoaded = true;
+        try
+        {
+            step.Logs       = await TaskService.GetTaskLogsAsync(step.Task.Id);
+            step.LogsLoaded = true;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"任務記錄載入失敗：{ex.Message}", Severity.Error);
+        }
         StateHasChanged();
     }
 

--- a/src/AiTeam.Dashboard/Components/Pages/Tasks/TaskCenter.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Tasks/TaskCenter.razor.cs
@@ -84,16 +84,24 @@ public partial class TaskCenter : IAsyncDisposable
         TableState state,
         CancellationToken cancellationToken)
     {
-        var result = await TaskService.GetTasksPagedAsync(
-            page: state.Page + 1,
-            pageSize: state.PageSize,
-            statusFilters: _statusFilters.ToHashSet());
-
-        return new TableData<TaskItemDto>
+        try
         {
-            Items      = result.Items,
-            TotalItems = result.TotalCount
-        };
+            var result = await TaskService.GetTasksPagedAsync(
+                page: state.Page + 1,
+                pageSize: state.PageSize,
+                statusFilters: _statusFilters.ToHashSet());
+
+            return new TableData<TaskItemDto>
+            {
+                Items      = result.Items,
+                TotalItems = result.TotalCount
+            };
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"任務清單載入失敗：{ex.Message}", Severity.Error);
+            return new TableData<TaskItemDto> { Items = [], TotalItems = 0 };
+        }
     }
 
     private async Task OnTaskRowClickAsync(TableRowClickEventArgs<TaskItemDto> args)
@@ -101,8 +109,15 @@ public partial class TaskCenter : IAsyncDisposable
         _selectedTask = args.Item;
         if (_selectedTask is null) return;
 
-        _selectedLogs     = await TaskService.GetTaskLogsAsync(_selectedTask.Id);
-        _isTaskDrawerOpen = true;
+        try
+        {
+            _selectedLogs     = await TaskService.GetTaskLogsAsync(_selectedTask.Id);
+            _isTaskDrawerOpen = true;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"載入任務記錄失敗：{ex.Message}", Severity.Error);
+        }
     }
 
     private async Task OnStatusFilterChangedAsync()

--- a/src/AiTeam.Dashboard/Components/Pages/Tokens/TokenMonitoring.razor
+++ b/src/AiTeam.Dashboard/Components/Pages/Tokens/TokenMonitoring.razor
@@ -23,6 +23,10 @@
 {
     <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
 }
+else if (_loadError is not null)
+{
+    <MudAlert Severity="Severity.Error" Class="mb-3">@_loadError</MudAlert>
+}
 else
 {
     <!-- 上方：Agent 卡片 -->

--- a/src/AiTeam.Dashboard/Components/Pages/Tokens/TokenMonitoring.razor.cs
+++ b/src/AiTeam.Dashboard/Components/Pages/Tokens/TokenMonitoring.razor.cs
@@ -26,13 +26,17 @@ public partial class TokenMonitoring : IAsyncDisposable
     [Inject]
     private IOptions<AgentTokenLimits> AgentLimitsOptions { get; set; } = null!;
 
+    [Inject]
+    private ISnackbar Snackbar { get; set; } = null!;
+
     private AgentTokenLimits AgentLimits => AgentLimitsOptions.Value;
 
     #endregion
 
     #region Private Variables
 
-    private bool             _loading = true;
+    private bool             _loading   = true;
+    private string?          _loadError;
     private string           _period  = "today";
     private TokenSummaryDto  _summary = new();
     private ChartSeries[]    _chartSeries = [];
@@ -68,31 +72,42 @@ public partial class TokenMonitoring : IAsyncDisposable
 
     private async Task LoadDataAsync()
     {
-        _loading = true;
+        _loading   = true;
+        _loadError = null;
         StateHasChanged();
 
-        var now = DateTime.UtcNow;
-        var (from, to) = _period switch
+        try
         {
-            "week"  => (now.Date.AddDays(-(int)now.DayOfWeek), now),
-            "month" => (new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc), now),
-            _       => (now.Date.ToUniversalTime(), now)
-        };
+            var now = DateTime.UtcNow;
+            var (from, to) = _period switch
+            {
+                "week"  => (now.Date.AddDays(-(int)now.DayOfWeek), now),
+                "month" => (new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc), now),
+                _       => (now.Date.ToUniversalTime(), now)
+            };
 
-        // 讀取費率設定
-        var inputSetting  = await AppSettingsService.GetAsync("TokenPricing:InputPer1kUsd");
-        var outputSetting = await AppSettingsService.GetAsync("TokenPricing:OutputPer1kUsd");
-        decimal.TryParse(inputSetting?.Value,  System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var inputRate);
-        decimal.TryParse(outputSetting?.Value, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var outputRate);
-        if (inputRate  == 0) inputRate  = 0.003m;
-        if (outputRate == 0) outputRate = 0.015m;
+            // 讀取費率設定
+            var inputSetting  = await AppSettingsService.GetAsync("TokenPricing:InputPer1kUsd");
+            var outputSetting = await AppSettingsService.GetAsync("TokenPricing:OutputPer1kUsd");
+            decimal.TryParse(inputSetting?.Value,  System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var inputRate);
+            decimal.TryParse(outputSetting?.Value, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var outputRate);
+            if (inputRate  == 0) inputRate  = 0.003m;
+            if (outputRate == 0) outputRate = 0.015m;
 
-        _summary = await TokenService.GetSummaryAsync(from, to, inputRate, outputRate);
+            _summary = await TokenService.GetSummaryAsync(from, to, inputRate, outputRate);
 
-        BuildChart();
-
-        _loading = false;
-        StateHasChanged();
+            BuildChart();
+        }
+        catch (Exception ex)
+        {
+            _loadError = $"Token 資料載入失敗：{ex.Message}";
+            Snackbar.Add(_loadError, Severity.Error);
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
     }
 
     private async Task ConnectSignalRAsync()

--- a/src/AiTeam.Dashboard/Program.cs
+++ b/src/AiTeam.Dashboard/Program.cs
@@ -1,5 +1,6 @@
 using AiTeam.Dashboard.Configuration;
 using AiTeam.Dashboard.Identity;
+using MudBlazor;
 using MudBlazor.Services;
 using AiTeam.Dashboard.Services;
 using AiTeam.Data;
@@ -23,7 +24,14 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 // MudBlazor
-builder.Services.AddMudServices();
+builder.Services.AddMudServices(config =>
+{
+    config.SnackbarConfiguration.PositionClass          = Defaults.Classes.Position.BottomRight;
+    config.SnackbarConfiguration.VisibleStateDuration   = 4000;
+    config.SnackbarConfiguration.ShowTransitionDuration = 300;
+    config.SnackbarConfiguration.HideTransitionDuration = 300;
+    config.SnackbarConfiguration.PreventDuplicates      = false;
+});
 
 // SignalR（Hub 定義在 AiTeam.Data）
 builder.Services.AddSignalR();

--- a/src/AiTeam.Tests.Playwright/Generated/PR110/VisualTests.cs
+++ b/src/AiTeam.Tests.Playwright/Generated/PR110/VisualTests.cs
@@ -1,0 +1,249 @@
+using Microsoft.Playwright;
+using Microsoft.Playwright.MSTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace AiTeam.Tests.Playwright.Generated
+{
+    [TestClass]
+    public class PR110_Snackbar錯誤通知視覺截圖測試 : PageTest
+    {
+        private string _dashboardUrl  = string.Empty;
+        private string _dashboardUser = string.Empty;
+        private string _dashboardPass = string.Empty;
+        private const string ScreenshotDir = "screenshots";
+
+        [TestInitialize]
+        public async Task 初始化測試環境()
+        {
+            _dashboardUrl  = Environment.GetEnvironmentVariable("DASHBOARD_URL")  ?? "http://localhost:5051";
+            _dashboardUser = Environment.GetEnvironmentVariable("DASHBOARD_USER") ?? string.Empty;
+            _dashboardPass = Environment.GetEnvironmentVariable("DASHBOARD_PASS") ?? string.Empty;
+
+            Directory.CreateDirectory(ScreenshotDir);
+
+            await 執行登入();
+        }
+
+        private async Task 執行登入()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/login");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+            var usernameInput = Page.Locator(
+                "input[type='text'], input[name='username'], input[name='email'], " +
+                "input[id*='user'], input[id*='email']").First;
+            var passwordInput = Page.Locator("input[type='password']").First;
+
+            if (await usernameInput.IsVisibleAsync())
+                await usernameInput.FillAsync(_dashboardUser);
+
+            if (await passwordInput.IsVisibleAsync())
+                await passwordInput.FillAsync(_dashboardPass);
+
+            var loginButton = Page.Locator(
+                "button[type='submit'], button:has-text('登入'), " +
+                "button:has-text('Login'), button:has-text('Sign in')").First;
+
+            if (await loginButton.IsVisibleAsync())
+                await loginButton.ClickAsync();
+
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        }
+
+        private async Task 切換暗色模式()
+        {
+            var darkModeToggle = Page.Locator(
+                "button[aria-label*='dark'], button[aria-label*='Dark'], " +
+                "button[aria-label*='暗色'], button[aria-label*='dark mode'], " +
+                "input[type='checkbox'][id*='dark'], input[type='checkbox'][id*='Dark'], " +
+                "[class*='dark-mode-toggle'], [class*='DarkModeToggle'], " +
+                "[class*='theme-toggle'], [class*='ThemeToggle'], " +
+                "button:has-text('Dark'), button:has-text('暗色'), " +
+                "button:has-text('🌙'), button:has-text('☀️'), " +
+                "[data-testid*='dark-mode'], [data-testid*='theme-toggle']"
+            ).First;
+
+            if (await darkModeToggle.IsVisibleAsync())
+            {
+                await darkModeToggle.ClickAsync();
+            }
+            else
+            {
+                await Page.EvaluateAsync(@"
+                    document.documentElement.classList.add('dark');
+                    document.documentElement.setAttribute('data-theme', 'dark');
+                    document.body.classList.add('dark-mode');
+                ");
+            }
+
+            await Page.WaitForTimeoutAsync(500);
+        }
+
+        // ── 系統設定頁（SystemSettings.razor）─────────────────────────────
+
+        [TestMethod]
+        public async Task 系統設定頁_亮色模式_完整頁面截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/system-settings");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR110_SystemSettings_light_full.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path     = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 系統設定頁_暗色模式_完整頁面截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/system-settings");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR110_SystemSettings_dark_full.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path     = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        // ── Agent 設定頁（AgentCreateDialog.razor 的父頁面）───────────────
+
+        [TestMethod]
+        public async Task Agent設定頁_亮色模式_完整頁面截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/agents");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR110_Agents_light_full.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path     = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task Agent設定頁_暗色模式_完整頁面截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/agents");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR110_Agents_dark_full.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path     = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        // ── 規則管理頁（RuleFormDialog.razor の父頁面）────────────────────
+
+        [TestMethod]
+        public async Task 規則管理頁_亮色模式_完整頁面截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/rules");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR110_Rules_light_full.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path     = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 規則管理頁_暗色模式_完整頁面截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/rules");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR110_Rules_dark_full.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path     = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        // ── 專案管理頁（ProjectCreateDialog.razor の父頁面）──────────────
+
+        [TestMethod]
+        public async Task 專案管理頁_亮色模式_完整頁面截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/projects");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR110_Projects_light_full.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path     = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+
+        [TestMethod]
+        public async Task 專案管理頁_暗色模式_完整頁面截圖驗證()
+        {
+            await Page.GotoAsync($"{_dashboardUrl}/projects");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForTimeoutAsync(1500);
+
+            await 切換暗色模式();
+            await Page.WaitForTimeoutAsync(1000);
+
+            var screenshotPath = Path.Combine(ScreenshotDir, "PR110_Projects_dark_full.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path     = screenshotPath,
+                FullPage = true
+            });
+
+            Assert.IsTrue(File.Exists(screenshotPath), $"截圖檔案應存在於 {screenshotPath}");
+            Assert.IsTrue(new FileInfo(screenshotPath).Length > 0, "截圖檔案不應為空");
+        }
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettingsTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettingsTests.cs
@@ -97,6 +97,119 @@ public class AgentSettingsTests
         GetField<bool>(instance, "_isSavingLlm").Should().BeTrue("guard clause 提早返回後旗標應未被 finally 重置");
     }
 
+    // ── SaveTrustLevelAsync：_formError 管理 ─────────────────────────────
+
+    [Fact]
+    public async Task SaveTrustLevelAsync_例外時_formError應包含錯誤說明()
+    {
+        var snackbar = Substitute.For<ISnackbar>();
+        var instance = CreateInstanceWithSnackbar(snackbar);
+        var agent = new AgentConfigDto { Id = Guid.NewGuid(), Name = "TestAgent" };
+        // _trustLevels 為空 dict → KeyNotFoundException 在 try 中被 catch 捕捉
+
+        await InvokeAsync(instance, "SaveTrustLevelAsync", agent);
+
+        var formError = GetField<string?>(instance, "_formError");
+        formError.Should().NotBeNull("例外應觸發 _formError 設定");
+        formError.Should().StartWith("信任等級儲存失敗：", "訊息應帶有識別前綴");
+    }
+
+    [Fact]
+    public async Task SaveTrustLevelAsync_例外時_Snackbar應被呼叫()
+    {
+        var snackbar = Substitute.For<ISnackbar>();
+        var instance = CreateInstanceWithSnackbar(snackbar);
+        var agent = new AgentConfigDto { Id = Guid.NewGuid(), Name = "TestAgent" };
+
+        await InvokeAsync(instance, "SaveTrustLevelAsync", agent);
+
+        snackbar.Received(1).Add(
+            Arg.Is<string>(s => s.StartsWith("信任等級儲存失敗：")),
+            Severity.Error,
+            Arg.Any<Action<SnackbarOptions>?>());
+    }
+
+    [Fact]
+    public async Task SaveTrustLevelAsync_例外時_isSaving應重置為False()
+    {
+        var snackbar = Substitute.For<ISnackbar>();
+        var instance = CreateInstanceWithSnackbar(snackbar);
+        var agent = new AgentConfigDto { Id = Guid.NewGuid(), Name = "TestAgent" };
+
+        await InvokeAsync(instance, "SaveTrustLevelAsync", agent);
+
+        GetField<bool>(instance, "_isSaving").Should().BeFalse("finally 區塊應重置 _isSaving");
+    }
+
+    [Fact]
+    public async Task SaveTrustLevelAsync_入口應清除舊formError()
+    {
+        var snackbar = Substitute.For<ISnackbar>();
+        var instance = CreateInstanceWithSnackbar(snackbar);
+        SetField(instance, "_formError", "舊錯誤訊息");
+        var agent = new AgentConfigDto { Id = Guid.NewGuid(), Name = "TestAgent" };
+
+        await InvokeAsync(instance, "SaveTrustLevelAsync", agent);
+
+        // 入口 _formError = null 後被 catch 設定新值，舊訊息應消失
+        GetField<string?>(instance, "_formError").Should().NotBe("舊錯誤訊息", "入口 _formError = null 應清除舊訊息");
+    }
+
+    // ── SaveTokenLimitsAsync：_formError 管理（exception path）────────────
+
+    [Fact]
+    public async Task SaveTokenLimitsAsync_例外時_formError應被設定()
+    {
+        var snackbar = Substitute.For<ISnackbar>();
+        var instance = CreateInstanceWithSnackbar(snackbar);
+        var agent = new AgentConfigDto { Id = Guid.NewGuid(), Name = "TestAgent" };
+        // AgentService 為 null → NullReferenceException 在 try 中被 catch 捕捉
+
+        await InvokeAsync(instance, "SaveTokenLimitsAsync", agent);
+
+        GetField<string?>(instance, "_formError").Should().NotBeNull("例外應觸發 _formError 設定");
+    }
+
+    [Fact]
+    public async Task SaveTokenLimitsAsync_例外時_Snackbar應被呼叫()
+    {
+        var snackbar = Substitute.For<ISnackbar>();
+        var instance = CreateInstanceWithSnackbar(snackbar);
+        var agent = new AgentConfigDto { Id = Guid.NewGuid(), Name = "TestAgent" };
+
+        await InvokeAsync(instance, "SaveTokenLimitsAsync", agent);
+
+        snackbar.Received(1).Add(
+            Arg.Any<string>(),
+            Severity.Error,
+            Arg.Any<Action<SnackbarOptions>?>());
+    }
+
+    [Fact]
+    public async Task SaveTokenLimitsAsync_例外時_isSavingLlm應重置為False()
+    {
+        var snackbar = Substitute.For<ISnackbar>();
+        var instance = CreateInstanceWithSnackbar(snackbar);
+        var agent = new AgentConfigDto { Id = Guid.NewGuid(), Name = "TestAgent" };
+
+        await InvokeAsync(instance, "SaveTokenLimitsAsync", agent);
+
+        GetField<bool>(instance, "_isSavingLlm").Should().BeFalse("finally 區塊應重置 _isSavingLlm");
+    }
+
+    [Fact]
+    public async Task SaveTokenLimitsAsync_入口應清除舊formError()
+    {
+        var snackbar = Substitute.For<ISnackbar>();
+        var instance = CreateInstanceWithSnackbar(snackbar);
+        SetField(instance, "_formError", "舊錯誤訊息");
+        var agent = new AgentConfigDto { Id = Guid.NewGuid(), Name = "TestAgent" };
+
+        await InvokeAsync(instance, "SaveTokenLimitsAsync", agent);
+
+        GetField<string?>(instance, "_formError").Should().NotBe("舊錯誤訊息", "入口 _formError = null 應清除舊訊息");
+    }
+
     // ── OnProviderChangedAsync：舊 Model 不在新 Provider 清單 ─────────────
 
     [Fact]

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettingsTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Agents/AgentSettingsTests.cs
@@ -1,0 +1,172 @@
+// 測試標的：AiTeam.Dashboard.Components.Pages.Agents.AgentSettings
+// 驗證：grep -r 'class AgentSettings' src/AiTeam.Dashboard/ → 命中 AgentSettings.razor.cs:12
+
+using System.Reflection;
+using AiTeam.Dashboard.Components.Pages.Agents;
+using AiTeam.Shared.Constants;
+using AiTeam.Shared.Dtos;
+using FluentAssertions;
+using MudBlazor;
+using NSubstitute;
+using Xunit;
+
+namespace AiTeam.Dashboard.Components.Pages.Agents.Tests;
+
+public class AgentSettingsTests
+{
+    private static AgentSettings CreateInstanceWithSnackbar(ISnackbar snackbar)
+    {
+        var instance = new AgentSettings();
+        typeof(AgentSettings)
+            .GetProperty("Snackbar", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, snackbar);
+        return instance;
+    }
+
+    private static AgentSettings CreateBareInstance()
+        => new AgentSettings();
+
+    private static void SetField(AgentSettings instance, string fieldName, object value)
+        => typeof(AgentSettings)
+            .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, value);
+
+    private static T? GetField<T>(AgentSettings instance, string fieldName)
+        => (T?)typeof(AgentSettings)
+            .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(instance);
+
+    private static async Task InvokeAsync(AgentSettings instance, string methodName, params object?[] args)
+    {
+        var method = typeof(AgentSettings)
+            .GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var result = method.Invoke(instance, args);
+        if (result is Task task) await task;
+    }
+
+    // ── ToggleIsActiveAsync：guard clause ────────────────────────────────
+
+    [Fact]
+    public async Task ToggleIsActiveAsync_已在切換中_應直接返回不拋出例外()
+    {
+        var instance = CreateBareInstance();
+        SetField(instance, "_isTogglingActive", true);
+        var agent = new AgentConfigDto { Id = Guid.NewGuid(), Name = "TestAgent" };
+
+        // AgentService 為 null，若未提前返回會拋 NRE
+        var act = async () => await InvokeAsync(instance, "ToggleIsActiveAsync", agent, true);
+
+        await act.Should().NotThrowAsync("guard clause 應在存取服務前返回");
+    }
+
+    [Fact]
+    public async Task ToggleIsActiveAsync_已在切換中_切換旗標應維持True()
+    {
+        var instance = CreateBareInstance();
+        SetField(instance, "_isTogglingActive", true);
+        var agent = new AgentConfigDto { Id = Guid.NewGuid(), Name = "TestAgent" };
+
+        await InvokeAsync(instance, "ToggleIsActiveAsync", agent, true);
+
+        GetField<bool>(instance, "_isTogglingActive").Should().BeTrue("guard clause 提早返回後旗標應未被修改");
+    }
+
+    // ── SaveTokenLimitsAsync：guard clause ───────────────────────────────
+
+    [Fact]
+    public async Task SaveTokenLimitsAsync_已在儲存LLM設定中_應直接返回不拋出例外()
+    {
+        var instance = CreateBareInstance();
+        SetField(instance, "_isSavingLlm", true);
+        var agent = new AgentConfigDto { Id = Guid.NewGuid(), Name = "TestAgent" };
+
+        var act = async () => await InvokeAsync(instance, "SaveTokenLimitsAsync", agent);
+
+        await act.Should().NotThrowAsync("guard clause 應在存取服務前返回");
+    }
+
+    [Fact]
+    public async Task SaveTokenLimitsAsync_已在儲存LLM設定中_旗標應維持True()
+    {
+        var instance = CreateBareInstance();
+        SetField(instance, "_isSavingLlm", true);
+        var agent = new AgentConfigDto { Id = Guid.NewGuid(), Name = "TestAgent" };
+
+        await InvokeAsync(instance, "SaveTokenLimitsAsync", agent);
+
+        GetField<bool>(instance, "_isSavingLlm").Should().BeTrue("guard clause 提早返回後旗標應未被 finally 重置");
+    }
+
+    // ── OnProviderChangedAsync：舊 Model 不在新 Provider 清單 ─────────────
+
+    [Fact]
+    public async Task OnProviderChangedAsync_切換至Anthropic但舊Model為Gemini_應清空Model()
+    {
+        var snackbar = Substitute.For<ISnackbar>();
+        var instance = CreateInstanceWithSnackbar(snackbar);
+        var agent = new AgentConfigDto
+        {
+            Provider = LlmModels.ProviderGemini,
+            Model    = "gemini-2.5-pro"
+        };
+
+        await InvokeAsync(instance, "OnProviderChangedAsync", agent, LlmModels.ProviderAnthropic);
+
+        agent.Model.Should().BeNull("gemini-2.5-pro 不在 Anthropic 清單中，應被清空");
+    }
+
+    [Fact]
+    public async Task OnProviderChangedAsync_切換至未知Provider_應清空Model()
+    {
+        var snackbar = Substitute.For<ISnackbar>();
+        var instance = CreateInstanceWithSnackbar(snackbar);
+        var agent = new AgentConfigDto
+        {
+            Provider = LlmModels.ProviderAnthropic,
+            Model    = "claude-sonnet-4-6"
+        };
+
+        await InvokeAsync(instance, "OnProviderChangedAsync", agent, "UnknownProvider");
+
+        agent.Model.Should().BeNull("未知 Provider 對應空 Model 清單，任何舊 Model 均應被清空");
+    }
+
+    // ── OnModelChangedAsync：空 Provider 提早返回 ────────────────────────
+
+    [Fact]
+    public async Task OnModelChangedAsync_Provider為空_應設定Model後提早返回不呼叫服務()
+    {
+        var instance = CreateBareInstance();
+        var agent = new AgentConfigDto { Provider = null, Model = null };
+
+        // AgentService 為 null；若未提早返回會拋 NRE
+        var act = async () => await InvokeAsync(instance, "OnModelChangedAsync", agent, "claude-sonnet-4-6");
+
+        await act.Should().NotThrowAsync("Provider 為空應提早返回");
+        agent.Model.Should().Be("claude-sonnet-4-6", "Model 賦值在 guard check 之前發生");
+    }
+
+    // ── SaveProviderModelAsync：Provider / Model 為空提早返回 ─────────────
+
+    [Fact]
+    public async Task SaveProviderModelAsync_Provider為空_應直接返回不呼叫服務()
+    {
+        var instance = CreateBareInstance();
+        var agent = new AgentConfigDto { Provider = "", Model = "claude-sonnet-4-6" };
+
+        var act = async () => await InvokeAsync(instance, "SaveProviderModelAsync", agent);
+
+        await act.Should().NotThrowAsync("Provider 為空應提早返回");
+    }
+
+    [Fact]
+    public async Task SaveProviderModelAsync_Model為空_應直接返回不呼叫服務()
+    {
+        var instance = CreateBareInstance();
+        var agent = new AgentConfigDto { Provider = LlmModels.ProviderAnthropic, Model = null };
+
+        var act = async () => await InvokeAsync(instance, "SaveProviderModelAsync", agent);
+
+        await act.Should().NotThrowAsync("Model 為空應提早返回");
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Deployments/DeploymentHistoryTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Deployments/DeploymentHistoryTests.cs
@@ -1,0 +1,118 @@
+// 測試標的：AiTeam.Dashboard.Components.Pages.Deployments.DeploymentHistory
+// 驗證：grep -r 'partial class DeploymentHistory' src/AiTeam.Dashboard/ → 命中 DeploymentHistory.razor.cs:5
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using AiTeam.Dashboard.Components.Pages.Deployments;
+using AiTeam.Dashboard.Services;
+using AiTeam.Shared.Dtos;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor;
+using NSubstitute;
+using Xunit;
+
+namespace AiTeam.Dashboard.Components.Pages.Deployments.Tests;
+
+public class DeploymentHistoryTests
+{
+    // ── 輔助 ──────────────────────────────────────────────────────────────────
+
+    private static void SetProperty(DeploymentHistory instance, string propertyName, object? value)
+        => typeof(DeploymentHistory)
+            .GetProperty(propertyName, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, value);
+
+    private static T? GetField<T>(DeploymentHistory instance, string fieldName)
+        => (T?)typeof(DeploymentHistory)
+            .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(instance);
+
+    // ── OnInitializedAsync：服務失敗（catch 路徑）────────────────────────────
+
+    [Fact]
+    public async Task OnInitializedAsync_服務拋出例外_不應拋出未處理例外()
+    {
+        var instance = new DeploymentHistory();
+        SetProperty(instance, "Snackbar", Substitute.For<ISnackbar>());
+        SetProperty(instance, "TaskService", new DashboardTaskService(null!));
+
+        var method = typeof(DeploymentHistory)
+            .GetMethod("OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        Func<Task> act = async () => await (Task)method.Invoke(instance, null)!;
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task OnInitializedAsync_服務拋出例外_deployments清單應為空()
+    {
+        var instance = new DeploymentHistory();
+        SetProperty(instance, "Snackbar", Substitute.For<ISnackbar>());
+        SetProperty(instance, "TaskService", new DashboardTaskService(null!));
+
+        var method = typeof(DeploymentHistory)
+            .GetMethod("OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        await (Task)method.Invoke(instance, null)!;
+
+        GetField<List<TaskItemDto>>(instance, "_deployments").Should().BeEmpty();
+    }
+
+    // ── OnRowClickAsync：null 防護 ────────────────────────────────────────────
+
+    [Fact]
+    public async Task OnRowClickAsync_Item為null_不應拋出例外且Drawer不應開啟()
+    {
+        var instance = new DeploymentHistory();
+        SetProperty(instance, "Snackbar", Substitute.For<ISnackbar>());
+        SetProperty(instance, "TaskService", new DashboardTaskService(null!));
+
+        var method = typeof(DeploymentHistory)
+            .GetMethod("OnRowClickAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var args = new TableRowClickEventArgs<TaskItemDto>();
+        Func<Task> act = async () => await (Task)method.Invoke(instance, new object[] { args })!;
+
+        await act.Should().NotThrowAsync();
+        GetField<bool>(instance, "_isDrawerOpen").Should().BeFalse("Item 為 null 時不應開啟 Drawer");
+    }
+
+    // ── OnRowClickAsync：服務失敗（catch 路徑）───────────────────────────────
+
+    [Fact]
+    public async Task OnRowClickAsync_服務拋出例外_Drawer不應開啟()
+    {
+        var instance = new DeploymentHistory();
+        SetProperty(instance, "Snackbar", Substitute.For<ISnackbar>());
+        SetProperty(instance, "TaskService", new DashboardTaskService(null!));
+
+        var method = typeof(DeploymentHistory)
+            .GetMethod("OnRowClickAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var args = new TableRowClickEventArgs<TaskItemDto>
+        {
+            Item = new TaskItemDto { Id = Guid.NewGuid(), Title = "Test Deploy" }
+        };
+        await (Task)method.Invoke(instance, new object[] { args })!;
+
+        GetField<bool>(instance, "_isDrawerOpen").Should().BeFalse("GetTaskLogsAsync 失敗時 Drawer 不應帶空資料開啟");
+    }
+
+    [Fact]
+    public async Task OnRowClickAsync_服務拋出例外_不應拋出未處理例外()
+    {
+        var instance = new DeploymentHistory();
+        SetProperty(instance, "Snackbar", Substitute.For<ISnackbar>());
+        SetProperty(instance, "TaskService", new DashboardTaskService(null!));
+
+        var method = typeof(DeploymentHistory)
+            .GetMethod("OnRowClickAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var args = new TableRowClickEventArgs<TaskItemDto>
+        {
+            Item = new TaskItemDto { Id = Guid.NewGuid(), Title = "Test Deploy" }
+        };
+        Func<Task> act = async () => await (Task)method.Invoke(instance, new object[] { args })!;
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Deployments/DeploymentHistoryTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Deployments/DeploymentHistoryTests.cs
@@ -71,7 +71,7 @@ public class DeploymentHistoryTests
 
         var method = typeof(DeploymentHistory)
             .GetMethod("OnRowClickAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        var args = new TableRowClickEventArgs<TaskItemDto>();
+        var args = new TableRowClickEventArgs<TaskItemDto>(new MouseEventArgs(), null!, null);
         Func<Task> act = async () => await (Task)method.Invoke(instance, new object[] { args })!;
 
         await act.Should().NotThrowAsync();
@@ -89,10 +89,8 @@ public class DeploymentHistoryTests
 
         var method = typeof(DeploymentHistory)
             .GetMethod("OnRowClickAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        var args = new TableRowClickEventArgs<TaskItemDto>
-        {
-            Item = new TaskItemDto { Id = Guid.NewGuid(), Title = "Test Deploy" }
-        };
+        var args = new TableRowClickEventArgs<TaskItemDto>(new MouseEventArgs(), null!,
+            new TaskItemDto { Id = Guid.NewGuid(), Title = "Test Deploy" });
         await (Task)method.Invoke(instance, new object[] { args })!;
 
         GetField<bool>(instance, "_isDrawerOpen").Should().BeFalse("GetTaskLogsAsync 失敗時 Drawer 不應帶空資料開啟");
@@ -107,10 +105,8 @@ public class DeploymentHistoryTests
 
         var method = typeof(DeploymentHistory)
             .GetMethod("OnRowClickAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        var args = new TableRowClickEventArgs<TaskItemDto>
-        {
-            Item = new TaskItemDto { Id = Guid.NewGuid(), Title = "Test Deploy" }
-        };
+        var args = new TableRowClickEventArgs<TaskItemDto>(new MouseEventArgs(), null!,
+            new TaskItemDto { Id = Guid.NewGuid(), Title = "Test Deploy" });
         Func<Task> act = async () => await (Task)method.Invoke(instance, new object[] { args })!;
 
         await act.Should().NotThrowAsync();

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Home/HomeTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Home/HomeTests.cs
@@ -1,0 +1,151 @@
+// 測試標的：AiTeam.Dashboard.Components.Pages.Home.Home
+// 驗證：grep -r 'partial class Home' src/AiTeam.Dashboard/ → 命中 Home.razor.cs:10
+
+using System.Collections.Generic;
+using System.Reflection;
+using AiTeam.Dashboard.Components.Pages.Home;
+using AiTeam.Shared.ViewModels;
+using FluentAssertions;
+using MudBlazor;
+using Xunit;
+
+namespace AiTeam.Dashboard.Components.Pages.Home.Tests;
+
+// 注意：ConnectSignalRAsync / OnInitializedAsync 含完整 SignalR 環境依賴，
+// 與 TaskCenter 同類型元件相同，整合測試不在此涵蓋。
+public class HomeTests
+{
+    // ── 輔助：呼叫私有靜態方法 ──────────────────────────────────────────────
+
+    private static string InvokeWorkflowTypeLabel(string? workflowType)
+    {
+        var method = typeof(Home).GetMethod(
+            "WorkflowTypeLabel",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (string)method.Invoke(null, new object?[] { workflowType })!;
+    }
+
+    private static Color InvokeWorkflowTypeColor(string? workflowType)
+    {
+        var method = typeof(Home).GetMethod(
+            "WorkflowTypeColor",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (Color)method.Invoke(null, new object?[] { workflowType })!;
+    }
+
+    private static void InvokeUpdateAgentStatus(Home instance, AgentStatusViewModel updated)
+    {
+        var method = typeof(Home).GetMethod(
+            "UpdateAgentStatus",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        method.Invoke(instance, new object[] { updated });
+    }
+
+    private static List<AgentStatusViewModel> GetAgentStatuses(Home instance)
+        => (List<AgentStatusViewModel>)typeof(Home)
+            .GetField("_agentStatuses", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(instance)!;
+
+    private static void SetAgentStatuses(Home instance, List<AgentStatusViewModel> statuses)
+        => typeof(Home)
+            .GetField("_agentStatuses", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, statuses);
+
+    // ── WorkflowTypeLabel ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void WorkflowTypeLabel_新功能類型_應回傳中文新功能標籤()
+    {
+        InvokeWorkflowTypeLabel("new_feature").Should().Be("新功能");
+    }
+
+    [Fact]
+    public void WorkflowTypeLabel_BugFix類型_應回傳BugFix標籤()
+    {
+        InvokeWorkflowTypeLabel("bug_fix").Should().Be("Bug Fix");
+    }
+
+    [Fact]
+    public void WorkflowTypeLabel_技術改善類型_應回傳技術改善標籤()
+    {
+        InvokeWorkflowTypeLabel("tech_improvement").Should().Be("技術改善");
+    }
+
+    [Fact]
+    public void WorkflowTypeLabel_未知類型_應回傳原始字串值()
+    {
+        InvokeWorkflowTypeLabel("unknown_type").Should().Be("unknown_type");
+    }
+
+    [Fact]
+    public void WorkflowTypeLabel_Null_應回傳空字串()
+    {
+        InvokeWorkflowTypeLabel(null).Should().Be("");
+    }
+
+    // ── WorkflowTypeColor ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void WorkflowTypeColor_新功能類型_應回傳Primary顏色()
+    {
+        InvokeWorkflowTypeColor("new_feature").Should().Be(Color.Primary);
+    }
+
+    [Fact]
+    public void WorkflowTypeColor_BugFix類型_應回傳Warning顏色()
+    {
+        InvokeWorkflowTypeColor("bug_fix").Should().Be(Color.Warning);
+    }
+
+    [Fact]
+    public void WorkflowTypeColor_技術改善類型_應回傳Secondary顏色()
+    {
+        InvokeWorkflowTypeColor("tech_improvement").Should().Be(Color.Secondary);
+    }
+
+    [Fact]
+    public void WorkflowTypeColor_未知類型_應回傳Default顏色()
+    {
+        InvokeWorkflowTypeColor("unknown_type").Should().Be(Color.Default);
+    }
+
+    [Fact]
+    public void WorkflowTypeColor_Null_應回傳Default顏色()
+    {
+        InvokeWorkflowTypeColor(null).Should().Be(Color.Default);
+    }
+
+    // ── UpdateAgentStatus ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void UpdateAgentStatus_Agent存在於清單中_應更新對應狀態()
+    {
+        var instance = new Home();
+        SetAgentStatuses(instance, new List<AgentStatusViewModel>
+        {
+            new() { AgentName = "Cody", Status = "idle" }
+        });
+
+        InvokeUpdateAgentStatus(instance, new AgentStatusViewModel { AgentName = "Cody", Status = "running" });
+
+        GetAgentStatuses(instance)[0].Status.Should().Be("running");
+    }
+
+    [Fact]
+    public void UpdateAgentStatus_Agent不在白名單清單中_清單長度不應改變且現有Agent不被取代()
+    {
+        var instance = new Home();
+        SetAgentStatuses(instance, new List<AgentStatusViewModel>
+        {
+            new() { AgentName = "Cody", Status = "idle" }
+        });
+
+        // "Dev_plan" 是 workflow-only 名稱，不在初始清單中，應被忽略（白名單過濾）
+        InvokeUpdateAgentStatus(instance, new AgentStatusViewModel { AgentName = "Dev_plan", Status = "running" });
+
+        var statuses = GetAgentStatuses(instance);
+        statuses.Should().HaveCount(1);
+        statuses[0].AgentName.Should().Be("Cody");
+        statuses[0].Status.Should().Be("idle");
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Home/QuickCommandCardTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Home/QuickCommandCardTests.cs
@@ -1,0 +1,86 @@
+// 測試標的：AiTeam.Dashboard.Components.Pages.Home.QuickCommandCard
+// 驗證：grep -r 'class QuickCommandCard' src/AiTeam.Dashboard/ → 命中 QuickCommandCard.razor.cs:6
+
+using System.Collections.Generic;
+using System.Reflection;
+using AiTeam.Dashboard.Components.Pages.Home;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components.Forms;
+using MudBlazor;
+using NSubstitute;
+using Xunit;
+
+namespace AiTeam.Dashboard.Components.Pages.Home.Tests;
+
+public class QuickCommandCardTests
+{
+    private static QuickCommandCard CreateInstanceWithSnackbar()
+    {
+        var instance = new QuickCommandCard();
+        var snackbar = Substitute.For<ISnackbar>();
+        typeof(QuickCommandCard)
+            .GetProperty("Snackbar", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, snackbar);
+        return instance;
+    }
+
+    private static void SetSelectedFiles(QuickCommandCard instance, IReadOnlyList<IBrowserFile>? files)
+    {
+        typeof(QuickCommandCard)
+            .GetField("_selectedFiles", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, files);
+    }
+
+    private static void InvokeOnFilesValidated(QuickCommandCard instance)
+    {
+        typeof(QuickCommandCard)
+            .GetMethod("OnFilesValidated", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(instance, null);
+    }
+
+    private static string? GetError(QuickCommandCard instance)
+        => typeof(QuickCommandCard)
+            .GetField("_error", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(instance) as string;
+
+    private static IReadOnlyList<IBrowserFile>? GetSelectedFiles(QuickCommandCard instance)
+        => typeof(QuickCommandCard)
+            .GetField("_selectedFiles", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(instance) as IReadOnlyList<IBrowserFile>;
+
+    // ── OnFilesValidated ──────────────────────────────────────────────────
+
+    [Fact]
+    public void OnFilesValidated_包含非圖片檔案_應過濾非圖片並設定錯誤訊息()
+    {
+        var instance = CreateInstanceWithSnackbar();
+
+        var nonImageFile = Substitute.For<IBrowserFile>();
+        nonImageFile.ContentType.Returns("application/pdf");
+        nonImageFile.Name.Returns("document.pdf");
+        nonImageFile.Size.Returns(1024L);
+
+        SetSelectedFiles(instance, new List<IBrowserFile> { nonImageFile });
+        InvokeOnFilesValidated(instance);
+
+        GetError(instance).Should().NotBeNull();
+        GetError(instance).Should().Contain("不是有效的圖片格式");
+        GetSelectedFiles(instance).Should().BeNull("非圖片應被過濾後剩0張，應設為null");
+    }
+
+    [Fact]
+    public void OnFilesValidated_有效圖片檔案_應不設定錯誤訊息()
+    {
+        var instance = CreateInstanceWithSnackbar();
+
+        var imageFile = Substitute.For<IBrowserFile>();
+        imageFile.ContentType.Returns("image/jpeg");
+        imageFile.Name.Returns("photo.jpg");
+        imageFile.Size.Returns(1024L);
+
+        SetSelectedFiles(instance, new List<IBrowserFile> { imageFile });
+        InvokeOnFilesValidated(instance);
+
+        GetError(instance).Should().BeNull("有效圖片應無錯誤訊息");
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Interactions/InteractionCenterTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Interactions/InteractionCenterTests.cs
@@ -1,0 +1,132 @@
+// 測試標的：AiTeam.Dashboard.Components.Pages.Interactions.InteractionCenter
+// 驗證：grep -r 'class InteractionCenter' src/AiTeam.Dashboard/ → 命中 InteractionCenter.razor.cs:8
+
+using System.Reflection;
+using AiTeam.Dashboard.Components.Pages.Interactions;
+using FluentAssertions;
+using MudBlazor;
+using Xunit;
+
+namespace AiTeam.Dashboard.Components.Pages.Interactions.Tests;
+
+public class InteractionCenterTests
+{
+    private static string InvokeGetInteractionIcon(string type)
+    {
+        var method = typeof(InteractionCenter).GetMethod(
+            "GetInteractionIcon",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (string)method.Invoke(null, new object?[] { type })!;
+    }
+
+    private static Color InvokeGetInteractionColor(string type)
+    {
+        var method = typeof(InteractionCenter).GetMethod(
+            "GetInteractionColor",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (Color)method.Invoke(null, new object?[] { type })!;
+    }
+
+    private static string InvokeGetInteractionLabel(string type)
+    {
+        var method = typeof(InteractionCenter).GetMethod(
+            "GetInteractionLabel",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (string)method.Invoke(null, new object?[] { type })!;
+    }
+
+    private static Color InvokeGetActionColor(string? action)
+    {
+        var method = typeof(InteractionCenter).GetMethod(
+            "GetActionColor",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (Color)method.Invoke(null, new object?[] { action })!;
+    }
+
+    // ── GetInteractionIcon ────────────────────────────────────────────────
+
+    [Fact]
+    public void GetInteractionIcon_ceo_confirm_應回傳Assignment圖示()
+    {
+        InvokeGetInteractionIcon("ceo_confirm").Should().Be(Icons.Material.Filled.Assignment);
+    }
+
+    [Fact]
+    public void GetInteractionIcon_未知類型_應回傳Notifications預設圖示()
+    {
+        InvokeGetInteractionIcon("unknown_type").Should().Be(Icons.Material.Filled.Notifications);
+    }
+
+    // ── GetInteractionColor ───────────────────────────────────────────────
+
+    [Fact]
+    public void GetInteractionColor_merge_notify_應回傳Success色()
+    {
+        InvokeGetInteractionColor("merge_notify").Should().Be(Color.Success);
+    }
+
+    [Fact]
+    public void GetInteractionColor_intervention_應回傳Error色()
+    {
+        InvokeGetInteractionColor("intervention").Should().Be(Color.Error);
+    }
+
+    [Fact]
+    public void GetInteractionColor_devplan_escalate_應回傳Warning色()
+    {
+        InvokeGetInteractionColor("devplan_escalate").Should().Be(Color.Warning);
+    }
+
+    [Fact]
+    public void GetInteractionColor_未知類型_應回傳Default色()
+    {
+        InvokeGetInteractionColor("unknown_type").Should().Be(Color.Default);
+    }
+
+    // ── GetInteractionLabel ───────────────────────────────────────────────
+
+    [Fact]
+    public void GetInteractionLabel_ceo_confirm_應回傳CEO決策確認()
+    {
+        InvokeGetInteractionLabel("ceo_confirm").Should().Be("CEO 決策確認");
+    }
+
+    [Fact]
+    public void GetInteractionLabel_merge_notify_應回傳全流程完成()
+    {
+        InvokeGetInteractionLabel("merge_notify").Should().Be("全流程完成");
+    }
+
+    [Fact]
+    public void GetInteractionLabel_未知類型_應直接回傳類型字串本身()
+    {
+        const string unknownType = "custom_unknown_type";
+        InvokeGetInteractionLabel(unknownType).Should().Be(unknownType);
+    }
+
+    // ── GetActionColor ────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetActionColor_confirm_yes_應回傳Success色()
+    {
+        InvokeGetActionColor("confirm_yes").Should().Be(Color.Success);
+    }
+
+    [Fact]
+    public void GetActionColor_confirm_no_應回傳Error色()
+    {
+        InvokeGetActionColor("confirm_no").Should().Be(Color.Error);
+    }
+
+    [Fact]
+    public void GetActionColor_devplan_skip_應回傳Warning色()
+    {
+        InvokeGetActionColor("devplan_skip").Should().Be(Color.Warning);
+    }
+
+    [Fact]
+    public void GetActionColor_Null_應回傳Default色()
+    {
+        InvokeGetActionColor(null).Should().Be(Color.Default);
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Projects/ProjectManagementTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Projects/ProjectManagementTests.cs
@@ -1,0 +1,90 @@
+// 測試標的：AiTeam.Dashboard.Components.Pages.Projects.ProjectManagement
+// 驗證：grep -r 'partial class ProjectManagement' src/AiTeam.Dashboard/ → 命中 ProjectManagement.razor.cs:5
+
+using System.Reflection;
+using AiTeam.Dashboard.Components.Pages.Projects;
+using AiTeam.Dashboard.Services;
+using AiTeam.Shared.Dtos;
+using FluentAssertions;
+using MudBlazor;
+using NSubstitute;
+using Xunit;
+
+namespace AiTeam.Dashboard.Components.Pages.Projects.Tests;
+
+public class ProjectManagementTests
+{
+    private static void SetProperty(ProjectManagement instance, string propertyName, object? value)
+        => typeof(ProjectManagement)
+            .GetProperty(propertyName, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, value);
+
+    private static T? GetField<T>(ProjectManagement instance, string fieldName)
+        => (T?)typeof(ProjectManagement)
+            .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(instance);
+
+    // ── OnInitializedAsync：載入失敗（catch 路徑）────────────────────────────
+
+    [Fact]
+    public async Task OnInitializedAsync_服務拋出例外_應設置_loadError欄位()
+    {
+        var instance = new ProjectManagement();
+        SetProperty(instance, "Snackbar", Substitute.For<ISnackbar>());
+        SetProperty(instance, "ProjectService", new DashboardProjectService(null!));
+
+        var method = typeof(ProjectManagement)
+            .GetMethod("OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        await (Task)method.Invoke(instance, null)!;
+
+        GetField<string?>(instance, "_loadError").Should().StartWith("專案清單載入失敗：");
+    }
+
+    [Fact]
+    public async Task OnInitializedAsync_服務拋出例外_不應拋出未處理例外()
+    {
+        var instance = new ProjectManagement();
+        SetProperty(instance, "Snackbar", Substitute.For<ISnackbar>());
+        SetProperty(instance, "ProjectService", new DashboardProjectService(null!));
+
+        var method = typeof(ProjectManagement)
+            .GetMethod("OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        Func<Task> act = async () => await (Task)method.Invoke(instance, null)!;
+
+        await act.Should().NotThrowAsync();
+    }
+
+    // ── ToggleIsActiveAsync：切換失敗（catch 路徑）──────────────────────────
+
+    [Fact]
+    public async Task ToggleIsActiveAsync_服務拋出例外_IsActive不應被更新()
+    {
+        var instance = new ProjectManagement();
+        SetProperty(instance, "Snackbar", Substitute.For<ISnackbar>());
+        SetProperty(instance, "ProjectService", new DashboardProjectService(null!));
+
+        var project = new ProjectDto { Id = Guid.NewGuid(), IsActive = false };
+
+        var method = typeof(ProjectManagement)
+            .GetMethod("ToggleIsActiveAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        await (Task)method.Invoke(instance, new object[] { project, true })!;
+
+        project.IsActive.Should().BeFalse("服務失敗時不應更新 IsActive");
+    }
+
+    [Fact]
+    public async Task ToggleIsActiveAsync_服務拋出例外_不應拋出未處理例外()
+    {
+        var instance = new ProjectManagement();
+        SetProperty(instance, "Snackbar", Substitute.For<ISnackbar>());
+        SetProperty(instance, "ProjectService", new DashboardProjectService(null!));
+
+        var project = new ProjectDto { Id = Guid.NewGuid(), IsActive = true };
+
+        var method = typeof(ProjectManagement)
+            .GetMethod("ToggleIsActiveAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        Func<Task> act = async () => await (Task)method.Invoke(instance, new object[] { project, false })!;
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagementTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Rules/RuleManagementTests.cs
@@ -1,0 +1,59 @@
+// 測試標的：AiTeam.Dashboard.Components.Pages.Rules.RuleManagement
+// 驗證：grep -r 'class RuleManagement' src/AiTeam.Dashboard/ → 命中 RuleManagement.razor.cs:5
+
+using System.Reflection;
+using AiTeam.Dashboard.Components.Pages.Rules;
+using FluentAssertions;
+using MudBlazor;
+using Xunit;
+
+namespace AiTeam.Dashboard.Components.Pages.Rules.Tests;
+
+public class RuleManagementTests
+{
+    private static Color InvokeGetAgentChipColor(string? agentName)
+    {
+        var method = typeof(RuleManagement).GetMethod(
+            "GetAgentChipColor",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (Color)method.Invoke(null, new object?[] { agentName })!;
+    }
+
+    // ── GetAgentChipColor ─────────────────────────────────────────────────
+
+    [Fact]
+    public void GetAgentChipColor_CEO_應回傳Primary色()
+    {
+        InvokeGetAgentChipColor("CEO").Should().Be(Color.Primary);
+    }
+
+    [Fact]
+    public void GetAgentChipColor_Dev_應回傳Info色()
+    {
+        InvokeGetAgentChipColor("Dev").Should().Be(Color.Info);
+    }
+
+    [Fact]
+    public void GetAgentChipColor_Reviewer_應回傳Error色()
+    {
+        InvokeGetAgentChipColor("Reviewer").Should().Be(Color.Error);
+    }
+
+    [Fact]
+    public void GetAgentChipColor_Release_應回傳Success色()
+    {
+        InvokeGetAgentChipColor("Release").Should().Be(Color.Success);
+    }
+
+    [Fact]
+    public void GetAgentChipColor_Null全域_應回傳Default色()
+    {
+        InvokeGetAgentChipColor(null).Should().Be(Color.Default);
+    }
+
+    [Fact]
+    public void GetAgentChipColor_未知AgentName_應回傳Default色()
+    {
+        InvokeGetAgentChipColor("UnknownAgent").Should().Be(Color.Default);
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettingsTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettingsTests.cs
@@ -1,0 +1,108 @@
+// 測試標的：AiTeam.Dashboard.Components.Pages.Settings.SystemSettings
+// 驗證：grep -r 'class SystemSettings' src/AiTeam.Dashboard/ → 命中 SystemSettings.razor.cs:5
+
+using System.Reflection;
+using AiTeam.Dashboard.Components.Pages.Settings;
+using FluentAssertions;
+using Xunit;
+
+namespace AiTeam.Dashboard.Components.Pages.Settings.Tests;
+
+public class SystemSettingsTests
+{
+    private static bool InvokeIsValidSnowflakeId(string value)
+    {
+        var method = typeof(SystemSettings).GetMethod(
+            "IsValidSnowflakeId",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (bool)method.Invoke(null, new object?[] { value })!;
+    }
+
+    private static SystemSettings CreateInstanceWithDelays(int min, int max)
+    {
+        var instance = new SystemSettings();
+        typeof(SystemSettings)
+            .GetField("_mockDelayMin", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, min);
+        typeof(SystemSettings)
+            .GetField("_mockDelayMax", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, max);
+        return instance;
+    }
+
+    private static bool InvokeIsMockDelayValid(SystemSettings instance)
+    {
+        var method = typeof(SystemSettings).GetMethod(
+            "IsMockDelayValid",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (bool)method.Invoke(instance, null)!;
+    }
+
+    // ── IsValidSnowflakeId ───────────────────────────────────────────────
+
+    [Fact]
+    public void IsValidSnowflakeId_有效的17位純數字_應回傳True()
+    {
+        InvokeIsValidSnowflakeId("12345678901234567").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidSnowflakeId_有效的20位純數字_應回傳True()
+    {
+        InvokeIsValidSnowflakeId("12345678901234567890").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidSnowflakeId_空字串代表清除_應回傳True()
+    {
+        InvokeIsValidSnowflakeId(string.Empty).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidSnowflakeId_16位數字太短_應回傳False()
+    {
+        InvokeIsValidSnowflakeId("1234567890123456").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidSnowflakeId_21位數字太長_應回傳False()
+    {
+        InvokeIsValidSnowflakeId("123456789012345678901").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidSnowflakeId_含有字母_應回傳False()
+    {
+        InvokeIsValidSnowflakeId("1234567890abcdefg").Should().BeFalse();
+    }
+
+    // ── IsMockDelayValid ─────────────────────────────────────────────────
+
+    [Fact]
+    public void IsMockDelayValid_最小0最大1000_應回傳True()
+    {
+        var instance = CreateInstanceWithDelays(0, 1000);
+        InvokeIsMockDelayValid(instance).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsMockDelayValid_最大等於最小_應回傳False()
+    {
+        var instance = CreateInstanceWithDelays(1000, 1000);
+        InvokeIsMockDelayValid(instance).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsMockDelayValid_最小為負數_應回傳False()
+    {
+        var instance = CreateInstanceWithDelays(-1, 1000);
+        InvokeIsMockDelayValid(instance).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsMockDelayValid_最大超過600000_應回傳False()
+    {
+        var instance = CreateInstanceWithDelays(0, 600001);
+        InvokeIsMockDelayValid(instance).Should().BeFalse();
+    }
+}

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineListTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineListTests.cs
@@ -1,8 +1,11 @@
 using System.Reflection;
 using AiTeam.Dashboard.Components.Pages.Tasks;
 using AiTeam.Dashboard.Helpers;
+using AiTeam.Dashboard.Services;
+using AiTeam.Shared.Dtos;
 using FluentAssertions;
 using MudBlazor;
+using NSubstitute;
 using Xunit;
 
 namespace AiTeam.Dashboard.Components.Pages.Tasks.Tests;
@@ -199,5 +202,51 @@ public class PipelineListTests
         var result = InvokeExtractPrNumber("https://github.com/org/repo/pull/");
 
         result.Should().Be("PR");
+    }
+
+    // -----------------------------------------------------------------------
+    // LoadGroupServerDataAsync — 服務失敗（catch 路徑）
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadGroupServerDataAsync_服務拋出例外_應回傳空集合()
+    {
+        var instance = new PipelineList();
+        typeof(PipelineList)
+            .GetProperty("Snackbar", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, Substitute.For<ISnackbar>());
+        typeof(PipelineList)
+            .GetProperty("TaskService", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, new DashboardTaskService(null!));
+
+        var method = typeof(PipelineList).GetMethod(
+            "LoadGroupServerDataAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        var result = await (Task<TableData<TaskGroupDto>>)method.Invoke(
+            instance, new object[] { new TableState(), CancellationToken.None })!;
+
+        result.Items.Should().BeEmpty();
+        result.TotalItems.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadGroupServerDataAsync_服務拋出例外_不應拋出未處理例外()
+    {
+        var instance = new PipelineList();
+        typeof(PipelineList)
+            .GetProperty("Snackbar", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, Substitute.For<ISnackbar>());
+        typeof(PipelineList)
+            .GetProperty("TaskService", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, new DashboardTaskService(null!));
+
+        var method = typeof(PipelineList).GetMethod(
+            "LoadGroupServerDataAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        Func<Task> act = async () => await (Task<TableData<TaskGroupDto>>)method.Invoke(
+            instance, new object[] { new TableState(), CancellationToken.None })!;
+
+        await act.Should().NotThrowAsync();
     }
 }

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineViewTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Tasks/PipelineViewTests.cs
@@ -2,9 +2,11 @@ using System;
 using System.Reflection;
 using AiTeam.Dashboard.Components.Pages.Tasks;
 using AiTeam.Dashboard.Helpers;
+using AiTeam.Dashboard.Services;
 using AiTeam.Shared.Dtos;
 using FluentAssertions;
 using MudBlazor;
+using NSubstitute;
 using Xunit;
 
 namespace AiTeam.Dashboard.Components.Pages.Tasks.Tests;
@@ -359,5 +361,92 @@ public class PipelineViewTests
     public void GetLogColor_未知狀態_應回傳Default顏色()
     {
         InvokeGetLogColor("unknown").Should().Be(Color.Default);
+    }
+
+    // -----------------------------------------------------------------------
+    // IsRevision — needs_intervention（Stage 43 補充）
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void IsRevision_needs_intervention狀態_應回傳True()
+    {
+        InvokeIsRevision("needs_intervention").Should().BeTrue(
+            because: "needs_intervention 屬於需要介入的修正類狀態");
+    }
+
+    // -----------------------------------------------------------------------
+    // GetLogColor — needs_intervention（Stage 43 補充）
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void GetLogColor_needs_intervention狀態_應回傳Warning顏色()
+    {
+        InvokeGetLogColor("needs_intervention").Should().Be(Color.Warning);
+    }
+
+    // -----------------------------------------------------------------------
+    // PipelineStepViewModel — 預設值
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void PipelineStepViewModel_預設值_LogsLoaded應為False()
+    {
+        var vm = new PipelineStepViewModel();
+
+        vm.LogsLoaded.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PipelineStepViewModel_預設值_Logs應為空列表且不為Null()
+    {
+        var vm = new PipelineStepViewModel();
+
+        vm.Logs.Should().NotBeNull();
+        vm.Logs.Should().BeEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // LoadStepsAsync — 服務失敗（catch 路徑）
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadStepsAsync_服務拋出例外_loading應重設為False()
+    {
+        var instance = new PipelineView();
+        instance.Group = new TaskGroupDto { Id = Guid.NewGuid() };
+        typeof(PipelineView)
+            .GetProperty("Snackbar", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, Substitute.For<ISnackbar>());
+        typeof(PipelineView)
+            .GetProperty("TaskService", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, new DashboardTaskService(null!));
+
+        var method = typeof(PipelineView).GetMethod(
+            "LoadStepsAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        await (Task)method.Invoke(instance, null)!;
+
+        var loading = (bool)typeof(PipelineView)
+            .GetField("_loading", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(instance)!;
+        loading.Should().BeFalse("finally 區塊應確保 _loading 重設為 false");
+    }
+
+    [Fact]
+    public async Task LoadStepsAsync_服務拋出例外_不應拋出未處理例外()
+    {
+        var instance = new PipelineView();
+        instance.Group = new TaskGroupDto { Id = Guid.NewGuid() };
+        typeof(PipelineView)
+            .GetProperty("Snackbar", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, Substitute.For<ISnackbar>());
+        typeof(PipelineView)
+            .GetProperty("TaskService", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, new DashboardTaskService(null!));
+
+        var method = typeof(PipelineView).GetMethod(
+            "LoadStepsAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        Func<Task> act = async () => await (Task)method.Invoke(instance, null)!;
+
+        await act.Should().NotThrowAsync();
     }
 }

--- a/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Tasks/TaskCenter.razorTests.cs
+++ b/tests/Generated/src/AiTeam.Dashboard/Components/Pages/Tasks/TaskCenter.razorTests.cs
@@ -299,4 +299,34 @@ public class TaskCenterTests
             result.Should().NotBeEmpty(because: $"duration={duration} 不應回傳空字串");
         }
     }
+
+    // -----------------------------------------------------------------------
+    // TriggeredByColor
+    // -----------------------------------------------------------------------
+
+    private static Color InvokeTriggeredByColor(string? triggeredBy)
+    {
+        var method = typeof(TaskCenter).GetMethod(
+            "TriggeredByColor",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (Color)method.Invoke(null, new object?[] { triggeredBy })!;
+    }
+
+    [Fact]
+    public void TriggeredByColor_Discord_應回傳Secondary色()
+    {
+        InvokeTriggeredByColor("Discord").Should().Be(Color.Secondary);
+    }
+
+    [Fact]
+    public void TriggeredByColor_Null_應回傳Default色()
+    {
+        InvokeTriggeredByColor(null).Should().Be(Color.Default);
+    }
+
+    [Fact]
+    public void TriggeredByColor_未知字串_應回傳Default色()
+    {
+        InvokeTriggeredByColor("UnknownSource").Should().Be(Color.Default);
+    }
 }


### PR DESCRIPTION
## 任務
Victoria，我想要打磨一下 Dashboard 的錯誤處理體驗。

最近在用的時候發現一個問題：很多操作失敗時，錯誤訊息只會顯示在表單區塊裡，但我視線可能在別的地方（例如剛點完按鈕在等結果），就完全錯過了。

舉個例子：首頁那個快速下達指令卡，如果我打的指令違規，提示就會在送出區上面冒出來，但有時候我已經滑下去看其他東西了，根本沒注意到指令沒送出去。

我希望能改成：表單裡的提示保留（緊貼違規來源），但同時要有個東西通知我「剛剛失敗了」，類似右下角彈出來的那種 toast 提示，讓我視線在哪裡都會看到。兩個地方訊息一致，toast 大概 3-5 秒自動消失就好。

不只快速下達指令卡，我覺得整個 Dashboard 凡是有「儲存失敗 / 操作失敗」的地方（系統設定、操作中心、Agent 設定、規則管理之類），都應該照同樣方式打磨一下。具體哪些頁面要動、要不要抽共用元件，你跟團隊判斷。

## Petra 動態決策
- Capability / Skill 序列：`code_implementation | code_review`
- Workers / Talents dispatch 順序：Cody → Vera

## Worker 完成 summary
- [Cody|code_implementation|outputLen=3012]
`Build succeeded`，0 errors。全部警告都是既有的（MSTest、obsolete、MUD0002），不是本次改動引入的。

---

<!-- IMPLEMENTATION_NOTE_START -->
## 實作摘要

### 背景與範圍

本次 task 是前 5 個 Petra session（9c72dd0–5f4689f）的收尾。前幾次已補齊大多數頁面的雙軌提示（inline MudAlert + 右下角 Snackbar），本次掃描後確認剩餘缺口並全部補完。

**全 Dashboard 範圍對照表（最終狀態）：**

| 頁面 / 操作 | inline 錯誤 | Snackbar | 狀態 |
|---|---|---|---|
| QuickCommandCard（表單送出）| `_error` MudAlert | ✓ | ✓ 已完成 |
| SystemSettings（所有儲存）| `_saveError` MudAlert | ✓ | ✓ 已完成 |
| TokenMonitoring（載入）| `_loadError` MudAlert | ✓ | ✓ 已完成 |
| InteractionCenter（頁面載入）| `_loadError` MudAlert | ✓ | ✓ 已完成 |
| **InteractionCenter（歷史列表載入）** | `_historyError` MudAlert | ✓ | **本次新增** |
| AgentSettings `SaveTrustLevel` / `SaveTokenLimits` | `_formError` MudAlert | ✓ | ✓ 已完成 |
| **AgentSettings `SaveProviderModel`** | `_formError` MudAlert | ✓ | **本次補齊（含前 session 未提交）** |
| **AgentSettings `ToggleIsActiveAsync`** | `_formError` MudAlert | ✓ | **本次新增** |
| AgentSettings 頁面載入 | `_loadError` MudAlert | ✓ | ✓ 已完成 |
| RuleManagement 頁面載入 | `_loadError` MudAlert | ✓ | **本次補齊（含前 session 未提交）** |
| DeploymentHistory 頁面載入 | `_loadError` MudAlert | ✓ | **本次補齊（含前 session 未提交）** |
| Home / ProjectManagement / PipelineList / PipelineView / TaskCenter | Snackbar only | ✓ | ✓ 可接受（純 action，無 form context）|
| RuleManagement toggle/delete、AgentSettings RestartBot、InteractionCenter HandleResponse、DeploymentHistory row click | Snackbar only | ✓ | ✓ 可接受（action 操作，非表單儲存）|

### 修改檔案清單

| 檔案 | 修改內容 |
|---|---|
| `AgentSettings.razor.cs` | `ToggleIsActiveAsync` 加 `_formError = null` 前置清除 + catch 設 `_formError` 並呼叫 Snackbar；`SaveProviderModelAsync` 加 `_formError` 雙軌（前 session 未提交） |
| `InteractionCenter.razor.cs` | 新增 `_historyError` 欄位；`LoadHistoryAsync` 加前置清除 + catch 設 `_historyError` 並呼叫 Snackbar |
| `InteractionCenter.razor` | 歷史區塊 `@if (_historyLoading) / else if / else` 結構中插入 `_historyError` MudAlert |
| `DeploymentHistory.razor` | 加 `_loadError` MudAlert（前 session 未提交） |
| `DeploymentHistory.razor.cs` | `_loadError` 欄位 + catc...(truncated)
- [Vera|code_review|outputLen=2029]
以下是審查結果：

{"critical":[],"warning":[{"id":1,"file":"src/AiTeam.Dashboard/Components/Pages/Deployments/DeploymentHistory.razor","line":16,"message":"_loadError alert 與空的 MudTable 同時顯示。載入失敗時 _deployments 為空陣列，使用者同時看到紅色錯誤 Banner + 零筆表格，容易誤判「本來就沒有部署紀錄」。建議改為 else 分支：`@if (_loadError is not null) { alert } else { table }`。（同上次 Review Warning 仍未修正）"},{"id":2,"file":"src/AiTeam.Dashboard/Components/Pages/Projects/ProjectManagement.razor","line":11,"message":"同 DeploymentHistory 問題：_loadError alert 與空 MudTable 同時顯示。建議加 else 分支隱藏空表格，與 RuleManagement 的 else-if 模式保持一致。"},{"id":3,"file":"src/AiTeam.Dashboard/Components/Pages/Interactions/InteractionCenter.razor","line":33,"message":"_loadError 設值（待處理載入失敗）時，_pending 為空、_isLoading 為 false，`_pending.Count == 0 && !_isLoading` 為 true，導致紅色錯誤 Banner 與藍色「目前沒有待處理的確認項目」Info Alert 同時並存，訊息語意衝突。建議將條件改為 `_pending.Count == 0 && !_isLoading && _loadError is null`。"},{"id":4,"file":"src/AiTeam.Dashboard/Components/Pages/Settings/SystemSettings.razor.cs","line":120,"message":"OnSkipCeoConfirmChanged / OnMockModeChanged / OnUseFrameworkAppealLoopChanged 等 toggle methods 成功時設 _saveMessage 但未清除 _saveError。若使用者先執行文字欄位儲存失敗（_saveError 有值），再成功切換 toggle，頁面將同時顯示成功訊息與紅色錯誤 Banner。建議在每個 toggle method try 開頭加 `_saveError = null;`。"}],"info":[],"summary":"雙軌提示補齊完整、try/catch 覆蓋正確；四處 UI 狀態管理建議改善：DeploymentHistory / ProjectManagement 載入失敗時空表格仍顯示、InteractionCenter 兩則語意衝突 alert 並存、SystemSettings toggle 成功不清舊錯誤 Banner。","impact":"### 直接影響\n- 12 個頁面 / Dialog 全面補齊 Snackbar 雙軌通知，使用者失焦時仍可看到操作結果。\n- `AgentSettings.razor.cs`：`ToggleIsActiveAsync` 包 try/catch，Circuit 斷線風險排除。\n- `InteractionCenter.razor.cs`：`LoadAsync` / `LoadHistoryAsync` 新增 `_loadError` / `_historyError` inline 顯示。\n- `SystemSettings.razor.cs`：所有儲存方法包 try/catch，toggle 失敗時還原 UI 狀態。\n\n### 潛在副作用\n- `DeploymentHistory` / `ProjectManagement`：載入失敗時 inline alert 下方仍有空 MudTable，與 `RuleManagement`（else-if）不一致。\n- `InteractionCenter`：待處理失敗時錯誤 Banner 與「無待處理」Info Alert 並存。\n- `SystemSettings`：_saveError 可能與成功 _save...(truncated)

---
🤖 由 AiTeam Petra Orchestrator（v5 動態架構 PoC）自動產出
